### PR TITLE
feat: render og image with templateConfig

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,20 +9,30 @@ const { renderOgImage } = require('./src/renderOgImage');
 globalThis.fetch = fetch;
 
 /**
- * @param { Parameters<getOutputParameters>[0] } eleventyConfig
+ * @param { import('@11ty/eleventy/src/UserConfig') } eleventyConfig
  * @param { import('eleventy-plugin-og-image').EleventyPluginOgImageOptions } pluginOptions
  * */
-module.exports = function eleventyPluginOgImage(eleventyConfig, pluginOptions) {
-  const { satoriOptions, sharpOptions, ...options } = mergeOptions(eleventyConfig, pluginOptions);
+module.exports = (eleventyConfig, pluginOptions) => {
+  let directoriesConfig;
+  eleventyConfig.on('eleventy.directories', (dir) => {
+    directoriesConfig = dir;
+  });
 
-  eleventyConfig.ignores.add(options.inputFileGlob);
+  let templateConfig;
+  eleventyConfig.on('eleventy.config', (config) => {
+    templateConfig = config;
+  });
+
+  eleventyConfig.ignores.add(mergeOptions(undefined, pluginOptions).inputFileGlob);
 
   eleventyConfig.addAsyncShortcode('ogImage', async (inputPath, data) => {
+    const { satoriOptions, sharpOptions, ...options } = mergeOptions(directoriesConfig, pluginOptions);
+
     if (!fs.existsSync(TemplatePath.normalizeOperatingSystemFilePath(inputPath))) {
       throw new Error(`Could not find file for the \`ogImage\` shortcode, looking for: ${inputPath}`);
     }
 
-    const { svg, pngBuffer } = await renderOgImage(inputPath, data, satoriOptions);
+    const { svg, pngBuffer } = await renderOgImage(inputPath, data, satoriOptions, templateConfig);
 
     const image = await sharp(pngBuffer).toFormat(options.outputFileExtension, sharpOptions);
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you would like to build your own shortcode, you can directly use the `renderO
 ```js
 const { renderOgImage } = require('eleventy-plugin-og-image/render');
 
-const { html, svg, pngBuffer } = await renderOgImage(inputPath, data, satoriOptions);
+const { html, svg, pngBuffer } = await renderOgImage(inputPath, data, satoriOptions, templateConfig);
 ```
 
 ### Capture Output URL

--- a/example/.eleventy.js
+++ b/example/.eleventy.js
@@ -5,6 +5,8 @@ const EleventyPluginOgImage = require('../.eleventy');
 
 /** @param { import('@11ty/eleventy/src/UserConfig') } eleventyConfig */
 module.exports = (eleventyConfig) => {
+  eleventyConfig.addShortcode('testShortcode', () => 'Eleventy Plugin OG Image');
+
   /** @type { import('eleventy-plugin-og-image').EleventyPluginOgImageOptions } */
   const eleventyPluginOgImageOptions = {
     outputFileExtension: 'png',

--- a/example/example-page.njk
+++ b/example/example-page.njk
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
+<head>
     <meta charset="utf-8" />
     <title>Eleventy Plugin OG Image</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    {% ogImage "./og-image.og.njk", { title: "Hello World! 👋", subTitle: "Eleventy Plugin OG Image" } %}
-  </head>
+    {% ogImage "./og-image.og.njk", { title: "Hello World! 👋" } %}
+</head>
 
-  <body>
-    <h1>Eleventy Plugin OG Image</h1>
-  </body>
+<body>
+<h1>Eleventy Plugin OG Image</h1>
+</body>
 </html>

--- a/example/og-image.og.njk
+++ b/example/og-image.og.njk
@@ -36,6 +36,6 @@
 <div class="root">
     <h1 class="title">{{ title }}</h1>
     <div class="card">
-        <h2 class="sub-title">{{ subTitle }}</h2>
+        <h2 class="sub-title">{% testShortcode %}</h2>
     </div>
 </div>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,25 +1,24 @@
 import { SatoriOptions } from 'satori';
 import { FormatEnum, Sharp } from 'sharp';
 
-declare type EleventyConfig = {
-  dir: {
-    input: string;
-    includes: string;
-    data: string;
-    output: string;
-  };
+type DirectoriesConfig = {
+  input: string;
+  includes: string;
+  data: string;
+  layouts?: string;
+  output: string;
 };
 
-declare type EleventyPluginOgImageOptions = {
+type EleventyPluginOgImageOptions = {
   inputFileGlob?: string;
   outputFileExtension?: keyof FormatEnum;
   outputDir?: string;
   urlPath?: string;
   hashLength?: number;
-  generateHTML: (outputUrl: string) => string,
+  generateHTML?: (outputUrl: string) => string;
 
   satoriOptions?: Partial<SatoriOptions>;
   sharpOptions?: Parameters<Sharp['toFormat']>[1];
 };
 
-export { EleventyPluginOgImageOptions };
+export { EleventyPluginOgImageOptions, DirectoriesConfig };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "postinstall": "node postinstall.js",
     "semantic-release": "semantic-release",
-    "test": "ava",
+    "test": "ava test/**/*.test.js",
     "lint": "eslint .",
     "format": "prettier --write .",
     "example": "cd example && eleventy",

--- a/src/mergeOptions.js
+++ b/src/mergeOptions.js
@@ -2,14 +2,14 @@ const path = require('path');
 
 module.exports = {
   /**
-   * @param { import('eleventy-plugin-og-image').EleventyConfig } eleventyConfig
+   * @param { import('eleventy-plugin-og-image').DirectoriesConfig } [directoriesConfig]
    * @param { import('eleventy-plugin-og-image').EleventyPluginOgImageOptions } [pluginOptions]
    * */
-  mergeOptions(eleventyConfig, pluginOptions) {
+  mergeOptions(directoriesConfig, pluginOptions) {
     return {
       inputFileGlob: '*.og.*',
       outputFileExtension: 'png',
-      outputDir: path.join(eleventyConfig.dir.output, 'og-images/'),
+      outputDir: path.join(directoriesConfig ? directoriesConfig.output : '', 'og-images/'),
       urlPath: '/og-images/',
       hashLength: 10,
       generateHTML: (outputUrl) => `<meta property="og:image" content="${outputUrl}" />`,

--- a/src/renderOgImage.js
+++ b/src/renderOgImage.js
@@ -9,9 +9,10 @@ module.exports = {
    * @param { string } inputPath
    * @param { Record<string, any> } [data]
    * @param { import('satori').SatoriOptions } satoriOptions
+   * @param { import('@11ty/eleventy/src/TemplateConfig') } [templateConfig]
    * */
-  async renderOgImage(inputPath, data, satoriOptions) {
-    const html = await (await File(inputPath))(data);
+  async renderOgImage(inputPath, data, satoriOptions, templateConfig) {
+    const html = await (await File(inputPath, { templateConfig }))(data);
     const svg = await satori(htmlToSatori(html), satoriOptions);
     const resvg = new Resvg(svg, { font: { loadSystemFonts: false } });
     const pngBuffer = resvg.render().asPng();

--- a/test/getOutputParameters.test.js
+++ b/test/getOutputParameters.test.js
@@ -1,11 +1,10 @@
 const test = require('ava');
 const { getOutputParameters } = require('../src/getOutputParameters');
 const { mergeOptions } = require('../src/mergeOptions');
-
-const eleventyConfig = { dir: { input: '.', includes: '_includes', data: '_data', output: '_site' } };
+const { directoriesConfig } = require('./utils/directoriesConfig');
 
 test('returns proper defaults', (t) => {
-  const { outputFilename, outputFilePath, outputUrl } = getOutputParameters('<svg />', mergeOptions(eleventyConfig));
+  const { outputFilename, outputFilePath, outputUrl } = getOutputParameters('<svg />', mergeOptions(directoriesConfig));
 
   const hash = '9o5yTSfY93';
 

--- a/test/mergeOptions.test.js
+++ b/test/mergeOptions.test.js
@@ -1,17 +1,16 @@
 const test = require('ava');
 const { mergeOptions } = require('../src/mergeOptions');
-
-const eleventyConfig = { dir: { input: '.', includes: '_includes', data: '_data', output: '_site' } };
+const { directoriesConfig } = require('./utils/directoriesConfig');
 
 test('works without pluginOptions', (t) => {
-  const { satoriOptions, sharpOptions, ...options } = mergeOptions(eleventyConfig);
+  const { satoriOptions, sharpOptions, ...options } = mergeOptions(directoriesConfig);
 
   t.truthy(options);
   t.truthy(satoriOptions);
 });
 
 test('creates default options', (t) => {
-  const { satoriOptions, sharpOptions, ...options } = mergeOptions(eleventyConfig);
+  const { satoriOptions, sharpOptions, ...options } = mergeOptions(directoriesConfig);
 
   t.is(options.outputFileExtension, 'png');
   t.is(options.inputFileGlob, '*.og.*');

--- a/test/utils/directoriesConfig.js
+++ b/test/utils/directoriesConfig.js
@@ -1,0 +1,4 @@
+/** @type { import('eleventy-plugin-og-image').DirectoriesConfig } */
+const directoriesConfig = { input: '.', includes: '_includes', data: '_data', output: '_site' };
+
+module.exports = { directoriesConfig };


### PR DESCRIPTION
Allows to use all functionalities (e.g. shortcodes) in the og image templates.

Closes #35 