### PR TITLE
Clear output folder on eleventy.build event

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -12,7 +12,7 @@ function rmDir(dirPath, removeSelf) {
   catch(e) { return; }
   if (files.length > 0)
     for (let i = 0; i < files.length; i++) {
-      let filePath = dirPath + '/' + files[i];
+      const filePath = `${dirPath}/${files[i]}`;
       if (fs.statSync(filePath).isFile())
         fs.unlinkSync(filePath);
       else
@@ -42,7 +42,7 @@ module.exports = (eleventyConfig, pluginOptions) => {
   if (pluginOptions.emptyOutputOnRebuild) {
     eleventyConfig.on('eleventy.before', () => {
       const options = mergeOptions(directoriesConfig, pluginOptions);
-      rmDir(options.outputDir); //empty output directory
+      rmDir(options.outputDir);
     });
   }
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -39,12 +39,10 @@ module.exports = (eleventyConfig, pluginOptions) => {
     templateConfig = config;
   });
   
-  if (pluginOptions.emptyOutputOnRebuild) {
-    eleventyConfig.on('eleventy.before', () => {
-      const options = mergeOptions(directoriesConfig, pluginOptions);
-      rmDir(options.outputDir);
-    });
-  }
+  eleventyConfig.on('eleventy.before', () => {
+    const options = mergeOptions(directoriesConfig, pluginOptions);
+    fs.rmSync(options.outputDir, { recursive: true, force: true });
+  });
 
   eleventyConfig.ignores.add(mergeOptions(undefined, pluginOptions).inputFileGlob);
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,22 +6,6 @@ const { mergeOptions } = require('./src/mergeOptions');
 const { getOutputParameters } = require('./src/getOutputParameters');
 const { renderOgImage } = require('./src/renderOgImage');
 
-function rmDir(dirPath, removeSelf) {
-  let files;
-  try { files = fs.readdirSync(dirPath); }
-  catch(e) { return; }
-  if (files.length > 0)
-    for (let i in files) {
-      const filePath = `${dirPath}/${files[i]}`;
-      if (fs.statSync(filePath).isFile())
-        fs.unlinkSync(filePath);
-      else
-        rmDir(filePath, true);
-    }
-  if (removeSelf)
-    fs.rmdirSync(dirPath);
-};
-
 globalThis.fetch = fetch;
 
 /**

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,7 +11,7 @@ function rmDir(dirPath, removeSelf) {
   try { files = fs.readdirSync(dirPath); }
   catch(e) { return; }
   if (files.length > 0)
-    for (let i = 0; i < files.length; i++) {
+    for (let i in files) {
       const filePath = `${dirPath}/${files[i]}`;
       if (fs.statSync(filePath).isFile())
         fs.unlinkSync(filePath);


### PR DESCRIPTION
This adds an `emptyOutputOnRebuild` flag that would clear the OG image directory when Eleventy rebuilds. I haven't had a chance to test this yet--gonna do that tonight.

If you want, I can change this to default to true.