### PR TITLE
fix: undefined export from eleventy package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "yoga-wasm-web": "^0.3.2"
       },
       "devDependencies": {
-        "@11ty/eleventy": "3.0.0-alpha.6",
+        "@11ty/eleventy": "3.0.0-alpha.5",
         "@fontsource/inter": "^5.0.1",
         "@kiwikilian/eslint-config": "^1.1.0",
         "@kiwikilian/prettier-config": "1.0.1",
@@ -35,7 +35,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@11ty/eleventy": ">=3.0.0-alpha.1"
+        "@11ty/eleventy": ">=3.0.0-alpha.5"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -59,20 +59,12 @@
         "normalize-path": "^3.0.0"
       }
     },
-    "node_modules/@11ty/dependency-tree-esm/node_modules/dependency-graph": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
-      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/@11ty/eleventy": {
-      "version": "3.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.0.0-alpha.6.tgz",
-      "integrity": "sha512-wllqMiM3A9qRt1mUA6iETQfhRtpFfUnzCT7v4RK/5RFqX/Bjwmqe18v7dfStHSO+V2zv5hE32skdM23HigG+eg==",
+      "version": "3.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.0.0-alpha.5.tgz",
+      "integrity": "sha512-JRWRqoAalwkiWIb9dQHmSX40kSOD6vhUwt73df/PWZPYzlAPxx27Gfi96TzR2bE+lmZ8IwgQzhYEBenL9tJ9Ow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@11ty/dependency-tree": "^3.0.0",
         "@11ty/dependency-tree-esm": "^1.0.0",
@@ -85,16 +77,16 @@
         "chokidar": "^3.6.0",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.4",
-        "dependency-graph": "^1.0.0",
+        "dependency-graph": "^0.11.0",
         "fast-glob": "^3.3.2",
         "graceful-fs": "^4.2.11",
         "gray-matter": "^4.0.3",
         "is-glob": "^4.0.3",
-        "iso-639-1": "^3.1.2",
+        "iso-639-1": "^3.1.0",
         "kleur": "^4.1.5",
-        "liquidjs": "^10.10.2",
+        "liquidjs": "^10.10.0",
         "luxon": "^3.4.4",
-        "markdown-it": "^14.1.0",
+        "markdown-it": "^14.0.0",
         "micromatch": "^4.0.5",
         "minimist": "^1.2.8",
         "moo": "^0.5.2",
@@ -4655,12 +4647,13 @@
       "dev": true
     },
     "node_modules/dependency-graph": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
-      "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/dequal": {

--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "node": ">=18"
   },
   "11ty": {
-    "compatibility": ">=3.0.0-alpha.1"
+    "compatibility": ">=3.0.0-alpha.5"
   },
   "peerDependencies": {
-    "@11ty/eleventy": ">=3.0.0-alpha.1"
+    "@11ty/eleventy": ">=3.0.0-alpha.5"
   },
   "dependencies": {
     "@11ty/eleventy-utils": "^1.0.1",
@@ -67,7 +67,7 @@
     "yoga-wasm-web": "^0.3.2"
   },
   "devDependencies": {
-    "@11ty/eleventy": "3.0.0-alpha.6",
+    "@11ty/eleventy": "3.0.0-alpha.5",
     "@fontsource/inter": "^5.0.1",
     "@kiwikilian/eslint-config": "^1.1.0",
     "@kiwikilian/prettier-config": "1.0.1",

--- a/src/OgImage.js
+++ b/src/OgImage.js
@@ -15,8 +15,6 @@ import path from 'node:path';
 import url from 'node:url';
 import { sortObject } from './utils/index.js';
 
-const { File } = RenderPlugin;
-
 const require = module.createRequire(import.meta.url);
 
 const Yoga = await initYoga(await fs.readFile(require.resolve('yoga-wasm-web/dist/yoga.wasm')));
@@ -61,7 +59,7 @@ export class OgImage {
   /** @returns {Promise<string>} */
   async html() {
     if (!this.results.html) {
-      this.results.html = await (await File(this.inputPath, { templateConfig: this.templateConfig }))(this.data);
+      this.results.html = await (await RenderPlugin.File(this.inputPath, { templateConfig: this.templateConfig }))(this.data);
     }
 
     return this.results.html;

--- a/src/OgImage.js
+++ b/src/OgImage.js
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import module from 'node:module';
-import { File } from '@11ty/eleventy/src/Plugins/RenderPlugin.js';
+import { RenderPlugin } from '@11ty/eleventy';
 /* eslint-disable import/no-unresolved */
 // https://github.com/import-js/eslint-plugin-import/issues/2132
 import { html as htmlToSatori } from 'satori-html';
@@ -14,6 +14,8 @@ import { TemplatePath } from '@11ty/eleventy-utils';
 import path from 'node:path';
 import url from 'node:url';
 import { sortObject } from './utils/index.js';
+
+const { File } = RenderPlugin;
 
 const require = module.createRequire(import.meta.url);
 


### PR DESCRIPTION
I curiously started running into the following error today:

```
Package subpath './src/Plugins/RenderPlugin.js' is not defined by "exports" in path/node_modules/@11ty/eleventy/package.json imported from path/node_modules/eleventy-plugin-og-image/src/OgImage.js

Original error stack trace: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './src/Plugins/RenderPlugin.js' is not defined by "exports" in path/node_modules/@11ty/eleventy/package.json imported from path/node_modules/eleventy-plugin-og-image/src/OgImage.js
    at exportsNotFound (node:internal/modules/esm/resolve:299:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:646:9)
    at packageResolve (node:internal/modules/esm/resolve:824:14)
    at moduleResolve (node:internal/modules/esm/resolve:914:18)
    at defaultResolve (node:internal/modules/esm/resolve:1119:11)
    at nextResolve (node:internal/modules/esm/hooks:791:28)
    at resolve (file://path/node_modules/@11ty/eleventy/src/Util/EsmResolver.js:25:11)
    at nextResolve (node:internal/modules/esm/hooks:791:28)
    at Hooks.resolve (node:internal/modules/esm/hooks:238:30)
    at handleMessage (node:internal/modules/esm/worker:255:24)
```

This PR aims to address this problem by instead importing `RenderPlugin` from `@11ty/eleventy` and then extracting `File` from `RenderPlugin`.

Apologies if I'm overlooking something obvious!