### PR TITLE
feat: add support for Eleventy extension map in OgImage class

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -25,8 +25,15 @@ export default async function (eleventyConfig, pluginOptions) {
   /** @type {import('@11ty/eleventy/src/TemplateConfig').default} */
   let templateConfig;
 
+  /** @type {import('@11ty/eleventy/src/EleventyExtensionMap').default} */
+  let extensionMap;
+
   eleventyConfig.on('eleventy.config', (newTemplateConfig) => {
     templateConfig = newTemplateConfig;
+  });
+
+  eleventyConfig.on('eleventy.extensionmap', (map) => {
+    extensionMap = map;
   });
 
   /** @type {boolean} */
@@ -90,6 +97,7 @@ export default async function (eleventyConfig, pluginOptions) {
         },
         options: mergedOptions,
         templateConfig,
+        extensionMap,
       });
 
       const outputFilePath = await ogImage.outputFilePath();

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,8 @@ export interface OgImage {
 
   templateConfig: typeof import('@11ty/eleventy/src/TemplateConfig').default;
 
+  extensionMap?: typeof import('@11ty/eleventy/src/EleventyExtensionMap').default;
+
   results: {
     html?: string;
     svg?: string;

--- a/src/OgImage.js
+++ b/src/OgImage.js
@@ -26,6 +26,9 @@ export class OgImage {
   /** @type {import('@11ty/eleventy/src/TemplateConfig').default} */
   templateConfig;
 
+  /** @type {import('@11ty/eleventy/src/EleventyExtensionMap').default | undefined} */
+  extensionMap;
+
   /**
    * @private
    * @type {{ html?: string; svg?: string; pngBuffer?: Buffer }}
@@ -41,19 +44,24 @@ export class OgImage {
    * @param {Record<string, any>} data
    * @param {import('eleventy-plugin-og-image').EleventyPluginOgImageMergedOptions} options
    * @param {import('@11ty/eleventy/src/TemplateConfig').default} templateConfig
+   * @param {import('@11ty/eleventy/src/EleventyExtensionMap').default} [extensionMap]
    */
-  constructor({ inputPath, data, options, templateConfig }) {
+  constructor({ inputPath, data, options, templateConfig, extensionMap }) {
     this.inputPath = inputPath;
     this.data = data;
     this.options = options;
     this.templateConfig = templateConfig;
+    this.extensionMap = extensionMap;
   }
 
   /** @returns {Promise<string>} */
   async html() {
     if (!this.results.html) {
       this.results.html = await (
-        await RenderPlugin.File(this.inputPath, { templateConfig: this.templateConfig })
+        await RenderPlugin.File(this.inputPath, {
+          templateConfig: this.templateConfig,
+          extensionMap: this.extensionMap,
+        })
       )(this.data);
     }
 


### PR DESCRIPTION
Using OG Image plugin on my blog game me this error:
> (node:9658) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 26 eleventy#templateModified listeners added to [AsyncEventEmitter]. MaxListeners is 25. Use emitter.setMaxListeners() to increase limit

Likely due to the number of images being generated all at once. I used Cursor AI to fix the issue. This is a fix for #293  

## Summary

- Fixes `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. N eleventy#templateModified listeners added to [AsyncEventEmitter]` when many pages use the `ogImage` shortcode (Node's default max is 25 listeners).
- Root cause: each `ogImage` call used `RenderPlugin.File()` with only `templateConfig`. When `extensionMap` is omitted, Eleventy creates a new `EleventyExtensionMap` and `TemplateEngineManager` per call. Each manager initializes template engines (e.g. Nunjucks) that register an `eleventy#templateModified` listener on the shared event emitter, so listener count grows with the number of `ogImage` invocations.
- Fix: capture Eleventy's shared `extensionMap` via the `eleventy.extensionmap` event (same pattern as Eleventy's own Render plugin) and pass it through `OgImage` into `RenderPlugin.File()`, so engines and listeners are reused across shortcode calls.

### Changes

- `.eleventy.js` — listen for `eleventy.extensionmap` and pass `extensionMap` into each `OgImage` instance
- `src/OgImage.js` — accept optional `extensionMap` and forward it to `RenderPlugin.File()`
- `index.d.ts` — type the optional `extensionMap` property

## Test plan

- [ ] Run `npm test`
- [ ] Build a site with 26+ pages that each call `{% ogImage ... %}` and confirm no `MaxListenersExceededWarning` is emitted
- [ ] Confirm OG images are still written correctly for those pages
- [ ] (Optional) Temporarily remove `extensionMap` from the `RenderPlugin.File()` options and confirm the warning returns with 26+ pages