### PR TITLE
perf: optimise OG image generation for large and incremental builds

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -117,9 +117,11 @@ export default async function (eleventyConfig, pluginOptions) {
       try {
         await fs.access(outputFilePath);
       } catch {
-        const image = await ogImage.render();
-
-        await image.toFile(outputFilePath);
+        if (ogImage.canPassthroughPng?.()) {
+          await ogImage.writeToFile(outputFilePath);
+        } else {
+          await (await ogImage.render()).toFile(outputFilePath);
+        }
 
         eleventyConfig.logger.log(
           `Writing ${TemplatePath.stripLeadingDotSlash(outputFilePath)} from ${joinedInputPath}`,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,6 +6,7 @@ import { mergeOptions } from './src/utils/index.js';
 import { OgImage } from './src/OgImage.js';
 import { BuildCache, buildCacheKey } from './src/buildCache.js';
 import { OgImageManifest } from './src/manifest.js';
+import { ConcurrencyLimiter } from './src/concurrencyLimiter.js';
 
 /**
  * @param {import('@11ty/eleventy/src/UserConfig').default} eleventyConfig
@@ -44,6 +45,7 @@ export default async function (eleventyConfig, pluginOptions) {
   const buildCache = new BuildCache();
   /** @type {OgImageManifest | undefined} */
   let manifest;
+  const renderLimiter = new ConcurrencyLimiter(pluginOptions?.maxConcurrency);
 
   eleventyConfig.on('eleventy.before', async ({ runMode }) => {
     buildCache.clear();
@@ -162,11 +164,13 @@ export default async function (eleventyConfig, pluginOptions) {
       try {
         await fs.access(outputFilePath);
       } catch {
-        if (ogImage.canPassthroughPng?.()) {
-          await ogImage.writeToFile(outputFilePath);
-        } else {
-          await (await ogImage.render()).toFile(outputFilePath);
-        }
+        await renderLimiter.run(async () => {
+          if (ogImage.canPassthroughPng?.()) {
+            await ogImage.writeToFile(outputFilePath);
+          } else {
+            await (await ogImage.render()).toFile(outputFilePath);
+          }
+        });
 
         eleventyConfig.logger.log(
           `Writing ${TemplatePath.stripLeadingDotSlash(outputFilePath)} from ${joinedInputPath}`,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,7 +4,8 @@ import path from 'node:path';
 import { TemplatePath } from '@11ty/eleventy-utils';
 import { mergeOptions } from './src/utils/index.js';
 import { OgImage } from './src/OgImage.js';
-import { BuildCache } from './src/buildCache.js';
+import { BuildCache, buildCacheKey } from './src/buildCache.js';
+import { OgImageManifest } from './src/manifest.js';
 
 /**
  * @param {import('@11ty/eleventy/src/UserConfig').default} eleventyConfig
@@ -41,12 +42,22 @@ export default async function (eleventyConfig, pluginOptions) {
   let previewEnabled;
 
   const buildCache = new BuildCache();
+  /** @type {OgImageManifest | undefined} */
+  let manifest;
 
   eleventyConfig.on('eleventy.before', async ({ runMode }) => {
     buildCache.clear();
+
     try {
       await fs.mkdir(mergedOptions.outputDir, { recursive: true });
     } catch {}
+
+    if (mergedOptions.manifest) {
+      manifest = new OgImageManifest(path.join(mergedOptions.outputDir, '.og-image-manifest.json'));
+      await manifest.load();
+    } else {
+      manifest = undefined;
+    }
 
     previewEnabled =
       mergedOptions.previewMode === 'auto' ? ['watch', 'serve'].includes(runMode) : mergedOptions.previewMode;
@@ -59,6 +70,12 @@ export default async function (eleventyConfig, pluginOptions) {
       try {
         await fs.rm(mergedOptions.previewDir, { recursive: true, force: true });
       } catch {}
+    }
+  });
+
+  eleventyConfig.on('eleventy.after', async () => {
+    if (manifest) {
+      await manifest.save();
     }
   });
 
@@ -86,26 +103,54 @@ export default async function (eleventyConfig, pluginOptions) {
         throw new Error(`Could not find file for the \`ogImage\` shortcode, looking for: ${joinedInputPath}`);
       }
 
+      const templateStat = await fs.stat(joinedInputPath);
+      const templateMtime = templateStat.mtimeMs;
+      const ogImageData = {
+        page: this.page,
+        eleventy: this.eleventy,
+        eleventyPluginOgImage: {
+          inputPath: joinedInputPath,
+          width: satoriOptions.width,
+          height: satoriOptions.height,
+          outputFileExtension: options.outputFileExtension,
+        },
+        ...data,
+      };
+
       const ogImage = new (pluginOptions.OgImage || OgImage)({
         inputPath: joinedInputPath,
-        data: {
-          page: this.page,
-          eleventy: this.eleventy,
-          eleventyPluginOgImage: {
-            inputPath: joinedInputPath,
-            width: satoriOptions.width,
-            height: satoriOptions.height,
-            outputFileExtension: options.outputFileExtension,
-          },
-          ...data,
-        },
+        data: ogImageData,
         options: mergedOptions,
         templateConfig,
         extensionMap,
         buildCache,
+        templateMtime,
       });
 
-      const outputFilePath = await ogImage.outputFilePath();
+      const dataHash = buildCacheKey(
+        joinedInputPath,
+        ogImageData,
+        mergedOptions.optionsHash,
+        templateMtime,
+      );
+
+      let outputFilePath;
+
+      if (manifest) {
+        const manifestEntry = manifest.get(this.page.url);
+
+        if (manifestEntry?.dataHash === dataHash) {
+          outputFilePath = TemplatePath.standardizeFilePath(
+            path.join(mergedOptions.outputDir, manifestEntry.outputFileName),
+          );
+          ogImage.resolvedOutputFileName = manifestEntry.outputFileName;
+        }
+      }
+
+      if (!outputFilePath) {
+        outputFilePath = await ogImage.outputFilePath();
+      }
+
       const cacheFilePath = await ogImage.cacheFilePath();
 
       if (cacheFilePath !== outputFilePath) {
@@ -126,6 +171,13 @@ export default async function (eleventyConfig, pluginOptions) {
         eleventyConfig.logger.log(
           `Writing ${TemplatePath.stripLeadingDotSlash(outputFilePath)} from ${joinedInputPath}`,
         );
+      }
+
+      if (manifest) {
+        manifest.set(this.page.url, {
+          dataHash,
+          outputFileName: ogImage.resolvedOutputFileName || path.basename(outputFilePath),
+        });
       }
 
       if (previewEnabled) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { TemplatePath } from '@11ty/eleventy-utils';
 import { mergeOptions } from './src/utils/index.js';
 import { OgImage } from './src/OgImage.js';
+import { BuildCache } from './src/buildCache.js';
 
 /**
  * @param {import('@11ty/eleventy/src/UserConfig').default} eleventyConfig
@@ -39,7 +40,10 @@ export default async function (eleventyConfig, pluginOptions) {
   /** @type {boolean} */
   let previewEnabled;
 
+  const buildCache = new BuildCache();
+
   eleventyConfig.on('eleventy.before', async ({ runMode }) => {
+    buildCache.clear();
     try {
       await fs.mkdir(mergedOptions.outputDir, { recursive: true });
     } catch {}
@@ -98,6 +102,7 @@ export default async function (eleventyConfig, pluginOptions) {
         options: mergedOptions,
         templateConfig,
         extensionMap,
+        buildCache,
       });
 
       const outputFilePath = await ogImage.outputFilePath();

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ yarn-error.log*
 
 # Artefacts
 .DS_Store
+
+# Test coverage
+/coverage/
+/.nyc_output/

--- a/README.md
+++ b/README.md
@@ -159,6 +159,20 @@ import { OgImage } from 'eleventy-plugin-og-image/og-image';
 const image = await new OgImage({ inputPath, data, options, templateConfig }).render();
 ```
 
+## Development
+
+Run the test suite:
+
+```shell
+npm test
+```
+
+Run tests with **100% coverage thresholds** (lines/branches/functions/statements) across `.eleventy.js` and `src/**/*.js`:
+
+```shell
+npm run test:coverage
+```
+
 ### Capture Output URL
 
 The plugins shortcode create a `meta` tag per default, modify the `shortcodeOutput` option or class function to directly return the `outputUrl`:

--- a/index.d.ts
+++ b/index.d.ts
@@ -85,6 +85,10 @@ type EleventyPluginOgImageMergedOptions = Omit<
 > &
   Pick<EleventyPluginOgImageOptions, 'sharpOptions'> & {
     optionsHash: string;
+    preparedOptionsForHash: {
+      satori: Record<string, unknown>;
+      sharp: Record<string, unknown>;
+    };
     satoriOptions: SatoriOptions & { width: number; height: number };
   };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,10 @@ export interface OgImage {
 
   render(): Promise<Sharp>;
 
+  canPassthroughPng(): boolean;
+
+  writeToFile(outputFilePath: string): Promise<void>;
+
   hash(): Promise<string>;
 
   outputFileSlug(): Promise<string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,10 @@ export interface OgImage {
 
   buildCache?: import('./src/buildCache.js').BuildCache;
 
+  templateMtime?: number;
+
+  resolvedOutputFileName?: string;
+
   results: {
     html?: string;
     svg?: string;
@@ -70,6 +74,7 @@ type EleventyPluginOgImageOptions = {
   previewDir?: string;
   urlPath?: string;
   slugStrategy?: 'contentHash' | 'pageUrl';
+  manifest?: boolean;
 
   outputFileSlug?(ogImage: OgImage): Promise<string>;
   shortcodeOutput?(ogImage: OgImage): Promise<string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,6 +75,7 @@ type EleventyPluginOgImageOptions = {
   urlPath?: string;
   slugStrategy?: 'contentHash' | 'pageUrl';
   manifest?: boolean;
+  maxConcurrency?: number;
 
   outputFileSlug?(ogImage: OgImage): Promise<string>;
   shortcodeOutput?(ogImage: OgImage): Promise<string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,7 @@ type EleventyPluginOgImageOptions = {
   previewMode?: 'auto' | boolean;
   previewDir?: string;
   urlPath?: string;
+  slugStrategy?: 'contentHash' | 'pageUrl';
 
   outputFileSlug?(ogImage: OgImage): Promise<string>;
   shortcodeOutput?(ogImage: OgImage): Promise<string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -78,6 +78,7 @@ type EleventyPluginOgImageMergedOptions = Omit<
   'OgImage' | 'satoriOptions' | 'sharpOptions'
 > &
   Pick<EleventyPluginOgImageOptions, 'sharpOptions'> & {
+    optionsHash: string;
     satoriOptions: SatoriOptions & { width: number; height: number };
   };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,8 @@ export interface OgImage {
 
   extensionMap?: typeof import('@11ty/eleventy/src/EleventyExtensionMap').default;
 
+  buildCache?: import('./src/buildCache.js').BuildCache;
+
   results: {
     html?: string;
     svg?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "ava": "8.0.1",
+        "c8": "^11.0.0",
         "eslint": "8.57.1",
         "prettier": "3.9.4",
         "prettier-plugin-jinja-template": "2.2.0",
@@ -590,6 +591,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@colors/colors": {
@@ -1390,6 +1401,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2823,6 +2844,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3991,6 +4019,139 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.0.0"
+      }
+    },
+    "node_modules/c8": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
+      "integrity": "sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^8.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/c8/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/c8/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/c8/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/c8/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/c8/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/c8/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/c8/node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/c8/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/call-bind": {
@@ -7061,6 +7222,36 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -7624,6 +7815,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "7.2.0",
@@ -8504,6 +8702,68 @@
         "node": "^18.17 || >=20.6.1"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
@@ -8903,6 +9163,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-it": {
@@ -14386,6 +14662,78 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -15004,6 +15352,21 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "scripts": {
     "semantic-release": "semantic-release",
     "test": "ava test/**/*.test.js",
+    "test:coverage": "c8 --100 --all --include=.eleventy.js --include=src/**/*.js ava test/**/*.test.js",
     "lint": "eslint .",
     "prettier": "prettier --write .",
     "example": "npx @11ty/eleventy --config=example/.eleventy.js --input=example --output=example/_site",
@@ -76,6 +77,7 @@
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "ava": "8.0.1",
+    "c8": "^11.0.0",
     "eslint": "8.57.1",
     "prettier": "3.9.4",
     "prettier-plugin-jinja-template": "2.2.0",

--- a/src/OgImage.js
+++ b/src/OgImage.js
@@ -43,6 +43,12 @@ export class OgImage {
   /** @type {import('./buildCache.js').BuildCache | undefined} */
   buildCache;
 
+  /** @type {number | undefined} */
+  templateMtime;
+
+  /** @type {string | undefined} */
+  resolvedOutputFileName;
+
   /**
    * @private
    * @type {string | undefined}
@@ -56,14 +62,16 @@ export class OgImage {
    * @param {import('@11ty/eleventy/src/TemplateConfig').default} templateConfig
    * @param {import('@11ty/eleventy/src/EleventyExtensionMap').default} [extensionMap]
    * @param {import('./buildCache.js').BuildCache} [buildCache]
+   * @param {number} [templateMtime]
    */
-  constructor({ inputPath, data, options, templateConfig, extensionMap, buildCache }) {
+  constructor({ inputPath, data, options, templateConfig, extensionMap, buildCache, templateMtime }) {
     this.inputPath = inputPath;
     this.data = data;
     this.options = options;
     this.templateConfig = templateConfig;
     this.extensionMap = extensionMap;
     this.buildCache = buildCache;
+    this.templateMtime = templateMtime;
   }
 
   /** @returns {string} */
@@ -73,6 +81,7 @@ export class OgImage {
         this.inputPath,
         this.data,
         this.options.optionsHash ?? '',
+        this.templateMtime,
       );
     }
 
@@ -200,6 +209,10 @@ export class OgImage {
 
   /** @returns {Promise<string>} */
   async outputFileName() {
+    if (this.resolvedOutputFileName) {
+      return this.resolvedOutputFileName;
+    }
+
     return `${await this.outputFileSlug()}.${this.options.outputFileExtension}`;
   }
 

--- a/src/OgImage.js
+++ b/src/OgImage.js
@@ -10,6 +10,7 @@ import crypto from 'node:crypto';
 import { TemplatePath } from '@11ty/eleventy-utils';
 import path from 'node:path';
 import url from 'node:url';
+import { buildCacheKey } from './buildCache.js';
 
 /** @implements {import('eleventy-plugin-og-image').OgImage} */
 export class OgImage {
@@ -38,23 +39,75 @@ export class OgImage {
     pngBuffer: undefined,
   };
 
+  /** @type {import('./buildCache.js').BuildCache | undefined} */
+  buildCache;
+
+  /**
+   * @private
+   * @type {string | undefined}
+   */
+  #cacheKey;
+
   /**
    * @param {string} inputPath
    * @param {Record<string, any>} data
    * @param {import('eleventy-plugin-og-image').EleventyPluginOgImageMergedOptions} options
    * @param {import('@11ty/eleventy/src/TemplateConfig').default} templateConfig
    * @param {import('@11ty/eleventy/src/EleventyExtensionMap').default} [extensionMap]
+   * @param {import('./buildCache.js').BuildCache} [buildCache]
    */
-  constructor({ inputPath, data, options, templateConfig, extensionMap }) {
+  constructor({ inputPath, data, options, templateConfig, extensionMap, buildCache }) {
     this.inputPath = inputPath;
     this.data = data;
     this.options = options;
     this.templateConfig = templateConfig;
     this.extensionMap = extensionMap;
+    this.buildCache = buildCache;
+  }
+
+  /** @returns {string} */
+  getCacheKey() {
+    if (!this.#cacheKey) {
+      this.#cacheKey = buildCacheKey(
+        this.inputPath,
+        this.data,
+        this.options.optionsHash ?? '',
+      );
+    }
+
+    return this.#cacheKey;
+  }
+
+  /** @private */
+  hydrateFromBuildCache() {
+    const cached = this.buildCache?.get(this.getCacheKey());
+
+    if (!cached) {
+      return;
+    }
+
+    if (cached.html) {
+      this.results.html = cached.html;
+    }
+
+    if (cached.svg) {
+      this.results.svg = cached.svg;
+    }
+
+    if (cached.pngBuffer) {
+      this.results.pngBuffer = cached.pngBuffer;
+    }
+  }
+
+  /** @private */
+  updateBuildCache() {
+    this.buildCache?.set(this.getCacheKey(), this.results);
   }
 
   /** @returns {Promise<string>} */
   async html() {
+    this.hydrateFromBuildCache();
+
     if (!this.results.html) {
       this.results.html = await (
         await RenderPlugin.File(this.inputPath, {
@@ -62,6 +115,8 @@ export class OgImage {
           extensionMap: this.extensionMap,
         })
       )(this.data);
+
+      this.updateBuildCache();
     }
 
     return this.results.html;
@@ -69,8 +124,11 @@ export class OgImage {
 
   /** @returns {Promise<string>} */
   async svg() {
+    this.hydrateFromBuildCache();
+
     if (!this.results.svg) {
       this.results.svg = await satori(htmlToSatori(await this.html()), this.options.satoriOptions);
+      this.updateBuildCache();
     }
 
     return this.results.svg;
@@ -78,8 +136,11 @@ export class OgImage {
 
   /** @returns {Promise<Buffer>} */
   async pngBuffer() {
+    this.hydrateFromBuildCache();
+
     if (!this.results.pngBuffer) {
       this.results.pngBuffer = await new Resvg(await this.svg(), { font: { loadSystemFonts: false } }).render().asPng();
+      this.updateBuildCache();
     }
 
     return this.results.pngBuffer;

--- a/src/OgImage.js
+++ b/src/OgImage.js
@@ -10,7 +10,6 @@ import crypto from 'node:crypto';
 import { TemplatePath } from '@11ty/eleventy-utils';
 import path from 'node:path';
 import url from 'node:url';
-import { sortObject } from './utils/index.js';
 
 /** @implements {import('eleventy-plugin-og-image').OgImage} */
 export class OgImage {
@@ -100,8 +99,14 @@ export class OgImage {
     const hash = crypto.createHash('sha256');
 
     hash.update(await this.html());
-    hash.update(JSON.stringify(sortObject(this.options.satoriOptions || {})));
-    hash.update(JSON.stringify(sortObject(this.options.sharpOptions || {})));
+
+    if (this.options.optionsHash !== undefined) {
+      hash.update(this.options.optionsHash);
+    } else {
+      const { computeOptionsHash } = await import('./utils/computeOptionsHash.js');
+
+      hash.update(computeOptionsHash(this.options.satoriOptions, this.options.sharpOptions));
+    }
 
     return hash.digest('hex').substring(0, this.options.hashLength);
   }

--- a/src/OgImage.js
+++ b/src/OgImage.js
@@ -1,4 +1,5 @@
 import { RenderPlugin } from '@11ty/eleventy';
+import { promises as fs } from 'node:fs';
 /* eslint-disable import/no-unresolved */
 // https://github.com/import-js/eslint-plugin-import/issues/2132
 import { html as htmlToSatori } from 'satori-html';
@@ -153,6 +154,26 @@ export class OgImage {
    */
   async render() {
     return sharp(await this.pngBuffer()).toFormat(this.options.outputFileExtension, this.options.sharpOptions);
+  }
+
+  /** @returns {boolean} */
+  canPassthroughPng() {
+    return this.options.outputFileExtension === 'png' && !this.options.sharpOptions;
+  }
+
+  /**
+   * Writes the rendered image to disk, skipping Sharp when PNG passthrough is possible.
+   *
+   * @param {string} outputFilePath
+   */
+  async writeToFile(outputFilePath) {
+    if (this.canPassthroughPng()) {
+      await fs.writeFile(outputFilePath, await this.pngBuffer());
+
+      return;
+    }
+
+    await (await this.render()).toFile(outputFilePath);
   }
 
   /** @returns {Promise<string>} */

--- a/src/buildCache.js
+++ b/src/buildCache.js
@@ -1,0 +1,81 @@
+import crypto from 'node:crypto';
+import { sortObject } from './utils/sortObject.js';
+
+/**
+ * @typedef {{ html?: string; svg?: string; pngBuffer?: Buffer }} BuildCacheEntry
+ */
+
+/**
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function serializeValue(value) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === 'function') {
+    return undefined;
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return value.toString('base64');
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(serializeValue).filter((entry) => entry !== undefined);
+  }
+
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, entryValue]) => typeof entryValue !== 'function')
+        .map(([key, entryValue]) => [key, serializeValue(entryValue)]),
+    );
+  }
+
+  return value;
+}
+
+/**
+ * @param {string} inputPath
+ * @param {Record<string, any>} data
+ * @param {string} optionsHash
+ * @returns {string}
+ */
+export function buildCacheKey(inputPath, data, optionsHash) {
+  const hash = crypto.createHash('sha256');
+
+  hash.update(inputPath);
+  hash.update(optionsHash);
+  hash.update(JSON.stringify(sortObject(serializeValue(data) || {})));
+
+  return hash.digest('hex');
+}
+
+export class BuildCache {
+  /** @type {Map<string, BuildCacheEntry>} */
+  #entries = new Map();
+
+  clear() {
+    this.#entries.clear();
+  }
+
+  /**
+   * @param {string} key
+   * @returns {BuildCacheEntry | undefined}
+   */
+  get(key) {
+    return this.#entries.get(key);
+  }
+
+  /**
+   * @param {string} key
+   * @param {BuildCacheEntry} entry
+   */
+  set(key, entry) {
+    const existing = this.#entries.get(key) || {};
+
+    this.#entries.set(key, { ...existing, ...entry });
+  }
+}

--- a/src/buildCache.js
+++ b/src/buildCache.js
@@ -41,14 +41,19 @@ function serializeValue(value) {
  * @param {string} inputPath
  * @param {Record<string, any>} data
  * @param {string} optionsHash
+ * @param {number} [templateMtime]
  * @returns {string}
  */
-export function buildCacheKey(inputPath, data, optionsHash) {
+export function buildCacheKey(inputPath, data, optionsHash, templateMtime) {
   const hash = crypto.createHash('sha256');
 
   hash.update(inputPath);
   hash.update(optionsHash);
   hash.update(JSON.stringify(sortObject(serializeValue(data) || {})));
+
+  if (templateMtime !== undefined) {
+    hash.update(String(templateMtime));
+  }
 
   return hash.digest('hex');
 }

--- a/src/concurrencyLimiter.js
+++ b/src/concurrencyLimiter.js
@@ -1,0 +1,61 @@
+export class ConcurrencyLimiter {
+  /** @type {number | undefined} */
+  #max;
+
+  /** @type {number} */
+  #running = 0;
+
+  /** @type {Array<() => void>} */
+  #queue = [];
+
+  /**
+   * @param {number | undefined} max
+   */
+  constructor(max) {
+    this.#max = max;
+  }
+
+  /**
+   * @template T
+   * @param {() => Promise<T>} task
+   * @returns {Promise<T>}
+   */
+  async run(task) {
+    if (!this.#max) {
+      return task();
+    }
+
+    await this.#acquire();
+
+    try {
+      return await task();
+    } finally {
+      this.#release();
+    }
+  }
+
+  /** @returns {Promise<void>} */
+  #acquire() {
+    if (this.#running < this.#max) {
+      this.#running++;
+
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      this.#queue.push(() => {
+        resolve();
+      });
+    });
+  }
+
+  #release() {
+    this.#running--;
+    const next = this.#queue.shift();
+
+    if (next) {
+      this.#running++;
+      next();
+    }
+  }
+}

--- a/src/concurrencyLimiter.js
+++ b/src/concurrencyLimiter.js
@@ -37,7 +37,7 @@ export class ConcurrencyLimiter {
   /** @returns {Promise<void>} */
   #acquire() {
     if (this.#running < this.#max) {
-      this.#running++;
+      this.#running += 1;
 
       return Promise.resolve();
     }
@@ -50,11 +50,11 @@ export class ConcurrencyLimiter {
   }
 
   #release() {
-    this.#running--;
+    this.#running -= 1;
     const next = this.#queue.shift();
 
     if (next) {
-      this.#running++;
+      this.#running += 1;
       next();
     }
   }

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -1,0 +1,55 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * @typedef {{ dataHash: string; outputFileName: string }} OgImageManifestEntry
+ */
+
+export class OgImageManifest {
+  /** @type {string} */
+  #manifestPath;
+
+  /** @type {Record<string, OgImageManifestEntry>} */
+  #entries = {};
+
+  /**
+   * @param {string} manifestPath
+   */
+  constructor(manifestPath) {
+    this.#manifestPath = manifestPath;
+  }
+
+  async load() {
+    try {
+      const contents = await fs.readFile(this.#manifestPath, 'utf8');
+
+      this.#entries = JSON.parse(contents);
+    } catch {
+      this.#entries = {};
+    }
+  }
+
+  async save() {
+    try {
+      await fs.mkdir(path.dirname(this.#manifestPath), { recursive: true });
+    } catch {}
+
+    await fs.writeFile(this.#manifestPath, `${JSON.stringify(this.#entries, null, 2)}\n`, 'utf8');
+  }
+
+  /**
+   * @param {string} pageUrl
+   * @returns {OgImageManifestEntry | undefined}
+   */
+  get(pageUrl) {
+    return this.#entries[pageUrl];
+  }
+
+  /**
+   * @param {string} pageUrl
+   * @param {OgImageManifestEntry} entry
+   */
+  set(pageUrl, entry) {
+    this.#entries[pageUrl] = entry;
+  }
+}

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -32,7 +32,9 @@ export class OgImageManifest {
   async save() {
     try {
       await fs.mkdir(path.dirname(this.#manifestPath), { recursive: true });
-    } catch {}
+    } catch {
+      // Directory may already exist.
+    }
 
     await fs.writeFile(this.#manifestPath, `${JSON.stringify(this.#entries, null, 2)}\n`, 'utf8');
   }

--- a/src/utils/computeOptionsHash.js
+++ b/src/utils/computeOptionsHash.js
@@ -27,15 +27,33 @@ function sanitizeFontData(value) {
 }
 
 /**
+ * @typedef {{ satori: Record<string, unknown>; sharp: Record<string, unknown> }} PreparedOptionsForHash
+ */
+
+/**
+ * Sorts and sanitizes options once so they can be reused for stable hashing.
+ *
+ * @param {import('satori').SatoriOptions | undefined} satoriOptions
+ * @param {import('sharp').Sharp['toFormat'] extends (format: infer F, options?: infer O) => any ? O : never} [sharpOptions]
+ * @returns {PreparedOptionsForHash}
+ */
+export function prepareOptionsForHash(satoriOptions, sharpOptions) {
+  return {
+    satori: sortObject(sanitizeFontData(satoriOptions || {})),
+    sharp: sortObject(sharpOptions || {}),
+  };
+}
+
+/**
  * Returns a stable string representation of satori and sharp options for hashing.
  *
  * @param {import('satori').SatoriOptions | undefined} satoriOptions
  * @param {import('sharp').Sharp['toFormat'] extends (format: infer F, options?: infer O) => any ? O : never} [sharpOptions]
+ * @param {PreparedOptionsForHash} [preparedOptionsForHash]
  * @returns {string}
  */
-export function computeOptionsHash(satoriOptions, sharpOptions) {
-  const sanitizedSatori = sortObject(sanitizeFontData(satoriOptions || {}));
-  const sortedSharp = sortObject(sharpOptions || {});
+export function computeOptionsHash(satoriOptions, sharpOptions, preparedOptionsForHash) {
+  const prepared = preparedOptionsForHash || prepareOptionsForHash(satoriOptions, sharpOptions);
 
-  return `${JSON.stringify(sanitizedSatori)}${JSON.stringify(sortedSharp)}`;
+  return `${JSON.stringify(prepared.satori)}${JSON.stringify(prepared.sharp)}`;
 }

--- a/src/utils/computeOptionsHash.js
+++ b/src/utils/computeOptionsHash.js
@@ -1,0 +1,41 @@
+import crypto from 'node:crypto';
+import { sortObject } from './sortObject.js';
+
+/**
+ * Replaces font data buffers with a stable digest so large binaries are not
+ * re-serialized on every hash computation.
+ *
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function sanitizeFontData(value) {
+  if (Buffer.isBuffer(value)) {
+    return crypto.createHash('sha256').update(value).digest('hex');
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(sanitizeFontData);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entryValue]) => [key, sanitizeFontData(entryValue)]),
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Returns a stable string representation of satori and sharp options for hashing.
+ *
+ * @param {import('satori').SatoriOptions | undefined} satoriOptions
+ * @param {import('sharp').Sharp['toFormat'] extends (format: infer F, options?: infer O) => any ? O : never} [sharpOptions]
+ * @returns {string}
+ */
+export function computeOptionsHash(satoriOptions, sharpOptions) {
+  const sanitizedSatori = sortObject(sanitizeFontData(satoriOptions || {}));
+  const sortedSharp = sortObject(sharpOptions || {});
+
+  return `${JSON.stringify(sanitizedSatori)}${JSON.stringify(sortedSharp)}`;
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,5 @@
-import { computeOptionsHash } from './computeOptionsHash.js';
+import { computeOptionsHash, prepareOptionsForHash } from './computeOptionsHash.js';
 import { mergeOptions } from './mergeOptions.js';
 import { sortObject } from './sortObject.js';
 
-export { computeOptionsHash, mergeOptions, sortObject };
+export { computeOptionsHash, mergeOptions, prepareOptionsForHash, sortObject };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
+import { computeOptionsHash } from './computeOptionsHash.js';
 import { mergeOptions } from './mergeOptions.js';
 import { sortObject } from './sortObject.js';
 
-export { mergeOptions, sortObject };
+export { computeOptionsHash, mergeOptions, sortObject };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,6 @@
 import { computeOptionsHash, prepareOptionsForHash } from './computeOptionsHash.js';
 import { mergeOptions } from './mergeOptions.js';
+import { pageUrlSlug } from './pageUrlSlug.js';
 import { sortObject } from './sortObject.js';
 
-export { computeOptionsHash, mergeOptions, prepareOptionsForHash, sortObject };
+export { computeOptionsHash, mergeOptions, pageUrlSlug, prepareOptionsForHash, sortObject };

--- a/src/utils/mergeOptions.js
+++ b/src/utils/mergeOptions.js
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { computeOptionsHash } from './computeOptionsHash.js';
+import { computeOptionsHash, prepareOptionsForHash } from './computeOptionsHash.js';
 
 /**
  * Merges the plugin options with defaults
@@ -21,6 +21,8 @@ export function mergeOptions({ directoriesConfig, pluginOptions }) {
     ...satoriOptions,
   };
 
+  const preparedOptionsForHash = prepareOptionsForHash(mergedSatoriOptions, sharpOptions);
+
   return {
     inputFileGlob: '**/*.og.*',
     hashLength: 8,
@@ -29,7 +31,8 @@ export function mergeOptions({ directoriesConfig, pluginOptions }) {
     previewMode: 'auto',
     previewDir: path.join(...(previewDir ? [eleventyOutput, previewDir] : [joinedOutputDir, 'preview'])),
     urlPath: urlPath || outputDir || 'og-images',
-    optionsHash: computeOptionsHash(mergedSatoriOptions, sharpOptions),
+    preparedOptionsForHash,
+    optionsHash: computeOptionsHash(mergedSatoriOptions, sharpOptions, preparedOptionsForHash),
 
     /** @param {OgImage} ogImage */
     outputFileSlug: (ogImage) => ogImage.hash(),

--- a/src/utils/mergeOptions.js
+++ b/src/utils/mergeOptions.js
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { computeOptionsHash, prepareOptionsForHash } from './computeOptionsHash.js';
+import { pageUrlSlug } from './pageUrlSlug.js';
 
 /**
  * Merges the plugin options with defaults
@@ -9,7 +10,17 @@ import { computeOptionsHash, prepareOptionsForHash } from './computeOptionsHash.
  * @returns {EleventyPluginOgImageMergedOptions}
  */
 export function mergeOptions({ directoriesConfig, pluginOptions }) {
-  const { outputDir, previewDir, urlPath, OgImage, satoriOptions, sharpOptions, ...options } = pluginOptions || {};
+  const {
+    outputDir,
+    previewDir,
+    urlPath,
+    OgImage,
+    satoriOptions,
+    sharpOptions,
+    slugStrategy = 'contentHash',
+    outputFileSlug,
+    ...options
+  } = pluginOptions || {};
 
   const eleventyOutput = directoriesConfig ? directoriesConfig.output : '';
   const joinedOutputDir = path.join(eleventyOutput, outputDir || 'og-images');
@@ -31,11 +42,20 @@ export function mergeOptions({ directoriesConfig, pluginOptions }) {
     previewMode: 'auto',
     previewDir: path.join(...(previewDir ? [eleventyOutput, previewDir] : [joinedOutputDir, 'preview'])),
     urlPath: urlPath || outputDir || 'og-images',
+    slugStrategy,
     preparedOptionsForHash,
     optionsHash: computeOptionsHash(mergedSatoriOptions, sharpOptions, preparedOptionsForHash),
 
     /** @param {OgImage} ogImage */
-    outputFileSlug: (ogImage) => ogImage.hash(),
+    outputFileSlug:
+      outputFileSlug ||
+      (async (ogImage) => {
+        if (ogImage.options.slugStrategy === 'pageUrl') {
+          return pageUrlSlug(ogImage.data);
+        }
+
+        return ogImage.hash();
+      }),
 
     /** @param {OgImage} ogImage */
     shortcodeOutput: async (ogImage) => `<meta property="og:image" content="${await ogImage.outputUrl()}" />`,

--- a/src/utils/mergeOptions.js
+++ b/src/utils/mergeOptions.js
@@ -19,6 +19,7 @@ export function mergeOptions({ directoriesConfig, pluginOptions }) {
     sharpOptions,
     slugStrategy = 'contentHash',
     outputFileSlug,
+    manifest = true,
     ...options
   } = pluginOptions || {};
 
@@ -43,6 +44,7 @@ export function mergeOptions({ directoriesConfig, pluginOptions }) {
     previewDir: path.join(...(previewDir ? [eleventyOutput, previewDir] : [joinedOutputDir, 'preview'])),
     urlPath: urlPath || outputDir || 'og-images',
     slugStrategy,
+    manifest,
     preparedOptionsForHash,
     optionsHash: computeOptionsHash(mergedSatoriOptions, sharpOptions, preparedOptionsForHash),
 

--- a/src/utils/mergeOptions.js
+++ b/src/utils/mergeOptions.js
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { computeOptionsHash } from './computeOptionsHash.js';
 
 /**
  * Merges the plugin options with defaults
@@ -8,10 +9,17 @@ import path from 'node:path';
  * @returns {EleventyPluginOgImageMergedOptions}
  */
 export function mergeOptions({ directoriesConfig, pluginOptions }) {
-  const { outputDir, previewDir, urlPath, OgImage, satoriOptions, ...options } = pluginOptions || {};
+  const { outputDir, previewDir, urlPath, OgImage, satoriOptions, sharpOptions, ...options } = pluginOptions || {};
 
   const eleventyOutput = directoriesConfig ? directoriesConfig.output : '';
   const joinedOutputDir = path.join(eleventyOutput, outputDir || 'og-images');
+
+  const mergedSatoriOptions = {
+    width: 1200,
+    height: 630,
+    fonts: [],
+    ...satoriOptions,
+  };
 
   return {
     inputFileGlob: '**/*.og.*',
@@ -21,6 +29,7 @@ export function mergeOptions({ directoriesConfig, pluginOptions }) {
     previewMode: 'auto',
     previewDir: path.join(...(previewDir ? [eleventyOutput, previewDir] : [joinedOutputDir, 'preview'])),
     urlPath: urlPath || outputDir || 'og-images',
+    optionsHash: computeOptionsHash(mergedSatoriOptions, sharpOptions),
 
     /** @param {OgImage} ogImage */
     outputFileSlug: (ogImage) => ogImage.hash(),
@@ -30,11 +39,6 @@ export function mergeOptions({ directoriesConfig, pluginOptions }) {
 
     ...options,
 
-    satoriOptions: {
-      width: 1200,
-      height: 630,
-      fonts: [],
-      ...satoriOptions,
-    },
+    satoriOptions: mergedSatoriOptions,
   };
 }

--- a/src/utils/mergeOptions.js
+++ b/src/utils/mergeOptions.js
@@ -20,6 +20,7 @@ export function mergeOptions({ directoriesConfig, pluginOptions }) {
     slugStrategy = 'contentHash',
     outputFileSlug,
     manifest = true,
+    maxConcurrency,
     ...options
   } = pluginOptions || {};
 
@@ -45,6 +46,7 @@ export function mergeOptions({ directoriesConfig, pluginOptions }) {
     urlPath: urlPath || outputDir || 'og-images',
     slugStrategy,
     manifest,
+    maxConcurrency,
     preparedOptionsForHash,
     optionsHash: computeOptionsHash(mergedSatoriOptions, sharpOptions, preparedOptionsForHash),
 

--- a/src/utils/pageUrlSlug.js
+++ b/src/utils/pageUrlSlug.js
@@ -1,0 +1,9 @@
+/**
+ * @param {{ page: { url: string } }} data
+ * @returns {string}
+ */
+export function pageUrlSlug(data) {
+  const pageUrl = data.page.url.replace(/\/$/, '') || 'index';
+
+  return pageUrl.replace(/^\//, '').replace(/\//g, '-');
+}

--- a/test/OgImage.test.js
+++ b/test/OgImage.test.js
@@ -1,4 +1,7 @@
 import test from 'ava';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import sharp from 'sharp';
 import { OgImage } from '../src/OgImage.js';
 import { testConstructor } from './utils/testConstructor.js';
@@ -34,6 +37,35 @@ test('pngBuffer returns Buffer', async (t) => {
   const pngBuffer = await ogImage.pngBuffer();
 
   t.true(pngBuffer instanceof Buffer);
+});
+
+test('writeToFile passthrough writes png buffer without sharp conversion', async (t) => {
+  const ogImage = new OgImage(testConstructor);
+  const pngBuffer = await ogImage.pngBuffer();
+
+  t.true(ogImage.canPassthroughPng());
+
+  const outputPath = path.join(os.tmpdir(), `og-image-passthrough-${process.pid}.png`);
+
+  t.teardown(async () => {
+    await fs.rm(outputPath, { force: true });
+  });
+
+  await ogImage.writeToFile(outputPath);
+
+  t.deepEqual(await fs.readFile(outputPath), pngBuffer);
+});
+
+test('writeToFile uses sharp when sharpOptions are set', async (t) => {
+  const ogImage = new OgImage({
+    ...testConstructor,
+    options: {
+      ...testConstructor.options,
+      sharpOptions: { quality: 80 },
+    },
+  });
+
+  t.false(ogImage.canPassthroughPng());
 });
 
 test('render returns sharp object', async (t) => {

--- a/test/OgImage.test.js
+++ b/test/OgImage.test.js
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import sharp from 'sharp';
 import { OgImage } from '../src/OgImage.js';
+import { BuildCache } from '../src/buildCache.js';
 import { testConstructor } from './utils/testConstructor.js';
 
 const PAGE_URL = 'example/url';
@@ -56,6 +57,42 @@ test('writeToFile passthrough writes png buffer without sharp conversion', async
   t.deepEqual(await fs.readFile(outputPath), pngBuffer);
 });
 
+test('build cache reuses svg and png buffers across instances', async (t) => {
+  const buildCache = new BuildCache();
+  const sharedData = { page: { url: '/shared/' }, title: 'Shared' };
+
+  const first = new OgImage({ ...testConstructor, data: sharedData, buildCache });
+  const second = new OgImage({ ...testConstructor, data: sharedData, buildCache });
+
+  await first.html();
+  await first.svg();
+  const firstPng = await first.pngBuffer();
+  const secondPng = await second.pngBuffer();
+
+  t.is(firstPng, secondPng);
+});
+
+test('writeToFile uses sharp when output is not png passthrough', async (t) => {
+  const ogImage = new OgImage({
+    ...testConstructor,
+    options: {
+      ...testConstructor.options,
+      outputFileExtension: 'jpeg',
+      sharpOptions: { quality: 80 },
+    },
+  });
+
+  const outputPath = path.join(os.tmpdir(), `og-image-sharp-${process.pid}.jpeg`);
+
+  t.teardown(async () => {
+    await fs.rm(outputPath, { force: true });
+  });
+
+  await ogImage.writeToFile(outputPath);
+
+  t.true((await fs.stat(outputPath)).size > 0);
+});
+
 test('writeToFile uses sharp when sharpOptions are set', async (t) => {
   const ogImage = new OgImage({
     ...testConstructor,
@@ -89,6 +126,16 @@ test('respects dimensions', async (t) => {
 
   t.is(width, 120);
   t.is(height, 63);
+});
+
+test('getCacheKey works when optionsHash is not set', (t) => {
+  const { optionsHash, ...optionsWithoutHash } = testConstructor.options;
+  const ogImage = new OgImage({
+    ...testConstructor,
+    options: optionsWithoutHash,
+  });
+
+  t.regex(ogImage.getCacheKey(), /^[a-f0-9]{64}$/);
 });
 
 test('returns cached result', async (t) => {

--- a/test/OgImage.test.js
+++ b/test/OgImage.test.js
@@ -108,10 +108,12 @@ test('hash returns hash', async (t) => {
 });
 
 test('hash handles missing satoriOptions and present sharpOptions', async (t) => {
+  const { optionsHash, ...optionsWithoutHash } = testConstructor.options;
+
   const ogImage = new OgImage({
     ...testConstructor,
     options: {
-      ...testConstructor.options,
+      ...optionsWithoutHash,
       satoriOptions: undefined,
       sharpOptions: { quality: 80 },
     },

--- a/test/OgImage.test.js
+++ b/test/OgImage.test.js
@@ -65,6 +65,37 @@ test('returns cached result', async (t) => {
   t.is(firstPngBuffer, secondPngBuffer);
 });
 
+test('outputUrl returns url path', async (t) => {
+  const ogImage = new OgImage(testConstructor);
+
+  const urlPath = await ogImage.outputUrl();
+
+  t.is(urlPath, `/og-images/${HASH}.png`);
+});
+
+test('cacheFilePath returns outputFilePath by default', async (t) => {
+  const ogImage = new OgImage(testConstructor);
+
+  t.is(await ogImage.cacheFilePath(), await ogImage.outputFilePath());
+});
+
+test('previewFilePath uses index for root url', (t) => {
+  const ogImage = new OgImage({ ...testConstructor, data: { page: { url: '/' } } });
+
+  t.is(ogImage.previewFilePath(), `./_site/og-images/preview/index.png`);
+});
+
+test('previewHtml includes rendered html, svg, and image tag', async (t) => {
+  const ogImage = new OgImage({ ...testConstructor, data: { page: { url: PAGE_URL } } });
+
+  const previewHtml = await ogImage.previewHtml();
+
+  t.regex(previewHtml, new RegExp(`<title>OG Image: ${PAGE_URL}</title>`));
+  t.regex(previewHtml, /<div id="eleventy-plugin-og-image-html">/);
+  t.regex(previewHtml, /^<html>/);
+  t.regex(previewHtml, new RegExp(`src=\"/og-images/${HASH}\\.png\"`));
+});
+
 const PAGE_URL = 'example/url';
 const HASH = '759d60a8';
 
@@ -74,6 +105,23 @@ test('hash returns hash', async (t) => {
   const hash = await ogImage.hash();
 
   t.is(hash, HASH);
+});
+
+test('hash handles missing satoriOptions and present sharpOptions', async (t) => {
+  const ogImage = new OgImage({
+    ...testConstructor,
+    options: {
+      ...testConstructor.options,
+      satoriOptions: undefined,
+      sharpOptions: { quality: 80 },
+    },
+  });
+
+  const hash = await ogImage.hash();
+
+  t.is(typeof hash, 'string');
+  t.regex(hash, /^[a-f0-9]{8}$/);
+  t.not(hash, HASH);
 });
 
 test('outputFileSlug returns hash', async (t) => {
@@ -92,6 +140,14 @@ test('outputFilePath returns file path', async (t) => {
   const ogImage = new OgImage(testConstructor);
 
   t.is(await ogImage.outputFilePath(), `./_site/og-images/${HASH}.png`);
+});
+
+test('shortcodeOutput returns meta tag with og:image', async (t) => {
+  const ogImage = new OgImage(testConstructor);
+
+  const output = await ogImage.shortcodeOutput();
+
+  t.regex(output, /^<meta property="og:image" content="\/og-images\//);
 });
 
 test('previewFilePath returns path', (t) => {

--- a/test/OgImage.test.js
+++ b/test/OgImage.test.js
@@ -3,6 +3,9 @@ import sharp from 'sharp';
 import { OgImage } from '../src/OgImage.js';
 import { testConstructor } from './utils/testConstructor.js';
 
+const PAGE_URL = 'example/url';
+const HASH = '759d60a8';
+
 test('html returns html string', async (t) => {
   const ogImage = new OgImage(testConstructor);
 
@@ -93,11 +96,8 @@ test('previewHtml includes rendered html, svg, and image tag', async (t) => {
   t.regex(previewHtml, new RegExp(`<title>OG Image: ${PAGE_URL}</title>`));
   t.regex(previewHtml, /<div id="eleventy-plugin-og-image-html">/);
   t.regex(previewHtml, /^<html>/);
-  t.regex(previewHtml, new RegExp(`src=\"/og-images/${HASH}\\.png\"`));
+  t.regex(previewHtml, new RegExp(`src="/og-images/${HASH}\\.png"`));
 });
-
-const PAGE_URL = 'example/url';
-const HASH = '759d60a8';
 
 test('hash returns hash', async (t) => {
   const ogImage = new OgImage(testConstructor);

--- a/test/buildCache.test.js
+++ b/test/buildCache.test.js
@@ -10,7 +10,7 @@ test('build cache deduplicates html rendering across OgImage instances', async (
 
   const originalFile = RenderPlugin.File;
   RenderPlugin.File = async () => {
-    renderCount++;
+    renderCount += 1;
 
     return async () => '<div class="root"></div>\n';
   };

--- a/test/buildCache.test.js
+++ b/test/buildCache.test.js
@@ -1,0 +1,41 @@
+import test from 'ava';
+import { RenderPlugin } from '@11ty/eleventy';
+import { OgImage } from '../src/OgImage.js';
+import { BuildCache } from '../src/buildCache.js';
+import { testConstructor } from './utils/testConstructor.js';
+
+test('build cache deduplicates html rendering across OgImage instances', async (t) => {
+  const buildCache = new BuildCache();
+  let renderCount = 0;
+
+  const originalFile = RenderPlugin.File;
+  RenderPlugin.File = async () => {
+    renderCount++;
+
+    return async () => '<div class="root"></div>\n';
+  };
+
+  t.teardown(() => {
+    RenderPlugin.File = originalFile;
+  });
+
+  const sharedData = { page: { url: '/shared/' }, title: 'Shared' };
+
+  const first = new OgImage({ ...testConstructor, data: sharedData, buildCache });
+  const second = new OgImage({ ...testConstructor, data: sharedData, buildCache });
+
+  const firstHtml = await first.html();
+  const secondHtml = await second.html();
+
+  t.is(renderCount, 1);
+  t.is(firstHtml, secondHtml);
+});
+
+test('build cache is cleared between builds', (t) => {
+  const buildCache = new BuildCache();
+
+  buildCache.set('key', { html: '<div></div>' });
+  buildCache.clear();
+
+  t.is(buildCache.get('key'), undefined);
+});

--- a/test/buildCache.test.js
+++ b/test/buildCache.test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import { RenderPlugin } from '@11ty/eleventy';
 import { OgImage } from '../src/OgImage.js';
-import { BuildCache } from '../src/buildCache.js';
+import { BuildCache, buildCacheKey } from '../src/buildCache.js';
 import { testConstructor } from './utils/testConstructor.js';
 
 test('build cache deduplicates html rendering across OgImage instances', async (t) => {
@@ -29,6 +29,30 @@ test('build cache deduplicates html rendering across OgImage instances', async (
 
   t.is(renderCount, 1);
   t.is(firstHtml, secondHtml);
+});
+
+test('buildCacheKey includes template mtime when provided', (t) => {
+  const data = { page: { url: '/shared/' } };
+
+  t.not(
+    buildCacheKey('./input.og.njk', data, 'options-hash'),
+    buildCacheKey('./input.og.njk', data, 'options-hash', 123),
+  );
+});
+
+test('buildCacheKey ignores functions and serializes buffers', (t) => {
+  const key = buildCacheKey(
+    './input.og.njk',
+    {
+      page: { url: '/' },
+      ignored: () => {},
+      bin: Buffer.from('x'),
+      nested: [{ fn: () => {} }, () => {}],
+    },
+    'options-hash',
+  );
+
+  t.regex(key, /^[a-f0-9]{64}$/);
 });
 
 test('build cache is cleared between builds', (t) => {

--- a/test/computeOptionsHash.test.js
+++ b/test/computeOptionsHash.test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { computeOptionsHash } from '../src/utils/index.js';
+import { computeOptionsHash, prepareOptionsForHash } from '../src/utils/index.js';
 
 test('computeOptionsHash is stable for identical options', (t) => {
   const satoriOptions = { width: 1200, height: 630, fonts: [] };
@@ -21,6 +21,20 @@ test('computeOptionsHash replaces font data buffers with digests', (t) => {
 
   t.false(withFont.includes('font-binary'));
   t.regex(withFont, /[a-f0-9]{64}/);
+});
+
+test('prepareOptionsForHash memoizes sorted option shapes', (t) => {
+  const satoriOptions = {
+    width: 1200,
+    height: 630,
+    fonts: [{ name: 'Inter', data: Buffer.from('font'), weight: 700, style: 'normal' }],
+  };
+
+  const prepared = prepareOptionsForHash(satoriOptions, { quality: 80 });
+
+  t.deepEqual(Object.keys(prepared.satori), ['fonts', 'height', 'width']);
+  t.deepEqual(Object.keys(prepared.sharp), ['quality']);
+  t.is(computeOptionsHash(satoriOptions, { quality: 80 }, prepared), computeOptionsHash(satoriOptions, { quality: 80 }));
 });
 
 test('computeOptionsHash matches legacy hash input for default options', (t) => {

--- a/test/computeOptionsHash.test.js
+++ b/test/computeOptionsHash.test.js
@@ -1,0 +1,33 @@
+import test from 'ava';
+import { computeOptionsHash } from '../src/utils/index.js';
+
+test('computeOptionsHash is stable for identical options', (t) => {
+  const satoriOptions = { width: 1200, height: 630, fonts: [] };
+  const sharpOptions = { quality: 80 };
+
+  t.is(computeOptionsHash(satoriOptions, sharpOptions), computeOptionsHash(satoriOptions, sharpOptions));
+});
+
+test('computeOptionsHash replaces font data buffers with digests', (t) => {
+  const fontData = Buffer.from('font-binary');
+  const withFont = computeOptionsHash(
+    {
+      width: 1200,
+      height: 630,
+      fonts: [{ name: 'Inter', data: fontData, weight: 700, style: 'normal' }],
+    },
+    undefined,
+  );
+
+  t.false(withFont.includes('font-binary'));
+  t.regex(withFont, /[a-f0-9]{64}/);
+});
+
+test('computeOptionsHash matches legacy hash input for default options', (t) => {
+  const satoriOptions = { width: 1200, height: 630, fonts: [] };
+
+  t.is(
+    computeOptionsHash(satoriOptions, undefined),
+    `${JSON.stringify({ fonts: {}, height: 630, width: 1200 })}${JSON.stringify({})}`,
+  );
+});

--- a/test/concurrencyLimiter.test.js
+++ b/test/concurrencyLimiter.test.js
@@ -7,10 +7,10 @@ test('concurrency limiter runs all tasks when maxConcurrency is unset', async (t
 
   await Promise.all([
     limiter.run(async () => {
-      count++;
+      count += 1;
     }),
     limiter.run(async () => {
-      count++;
+      count += 1;
     }),
   ]);
 
@@ -25,12 +25,12 @@ test('concurrency limiter limits parallel execution', async (t) => {
   await Promise.all(
     Array.from({ length: 3 }, () =>
       limiter.run(async () => {
-        running++;
+        running += 1;
         maxRunning = Math.max(maxRunning, running);
         await new Promise((resolve) => {
           setTimeout(resolve, 10);
         });
-        running--;
+        running -= 1;
       }),
     ),
   );

--- a/test/concurrencyLimiter.test.js
+++ b/test/concurrencyLimiter.test.js
@@ -1,0 +1,39 @@
+import test from 'ava';
+import { ConcurrencyLimiter } from '../src/concurrencyLimiter.js';
+
+test('concurrency limiter runs all tasks when maxConcurrency is unset', async (t) => {
+  const limiter = new ConcurrencyLimiter(undefined);
+  let count = 0;
+
+  await Promise.all([
+    limiter.run(async () => {
+      count++;
+    }),
+    limiter.run(async () => {
+      count++;
+    }),
+  ]);
+
+  t.is(count, 2);
+});
+
+test('concurrency limiter limits parallel execution', async (t) => {
+  const limiter = new ConcurrencyLimiter(1);
+  let running = 0;
+  let maxRunning = 0;
+
+  await Promise.all(
+    Array.from({ length: 3 }, () =>
+      limiter.run(async () => {
+        running++;
+        maxRunning = Math.max(maxRunning, running);
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+        running--;
+      }),
+    ),
+  );
+
+  t.is(maxRunning, 1);
+});

--- a/test/eleventy-build.integration.test.js
+++ b/test/eleventy-build.integration.test.js
@@ -1,0 +1,153 @@
+import test from 'ava';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import Eleventy from '@11ty/eleventy';
+
+async function pathExists(p) {
+  return fs
+    .access(p)
+    .then(() => true)
+    .catch(() => false);
+}
+
+async function mkTmpDir(t) {
+  const dir = path.join(os.tmpdir(), `eleventy-plugin-og-image-int-${process.pid}-${Date.now()}`);
+  await fs.mkdir(dir, { recursive: true });
+  t.teardown(async () => {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+    } catch {}
+  });
+  return dir;
+}
+
+test.serial('integration: Eleventy build writes html + og image output', async (t) => {
+  const root = await mkTmpDir(t);
+  const inputDir = path.join(root, 'input');
+  const outputDir = path.join(root, '_site');
+
+  await fs.mkdir(inputDir, { recursive: true });
+
+  // Minimal OG template without text (no fonts/network required)
+  await fs.writeFile(
+    path.join(inputDir, 'og-test.og.njk'),
+    `<style>
+  .root { width: 100%; height: 100%; background: #f0f; display: flex; }
+</style>
+<div class="root"></div>
+`,
+    'utf8',
+  );
+
+  await fs.writeFile(
+    path.join(inputDir, 'page.njk'),
+    `<!doctype html>
+<html>
+  <head>
+    {% ogImage "./og-test.og.njk" %}
+  </head>
+  <body>ok</body>
+</html>
+`,
+    'utf8',
+  );
+
+  const repoRoot = path.resolve('.');
+  const configPath = path.join(root, '.eleventy.js');
+
+  await fs.writeFile(
+    configPath,
+    `import EleventyPluginOgImage from ${JSON.stringify(path.join(repoRoot, '.eleventy.js'))};
+
+/** @param {import('@11ty/eleventy/src/UserConfig').default} eleventyConfig */
+export default async function (eleventyConfig) {
+  eleventyConfig.addPlugin(EleventyPluginOgImage, {
+    // Make output deterministic for assertions
+    outputFileSlug: async () => "fixed",
+    outputFileExtension: "png",
+    outputDir: "og-images",
+    urlPath: "og-images",
+    previewMode: false,
+    satoriOptions: { width: 120, height: 63, fonts: [] },
+  });
+};
+`,
+    'utf8',
+  );
+
+  const elev = new Eleventy(inputDir, outputDir, {
+    configPath,
+    quietMode: true,
+  });
+
+  await elev.init();
+  await elev.write();
+
+  const htmlOutPath = path.join(outputDir, 'page', 'index.html');
+  const imageOutPath = path.join(outputDir, 'og-images', 'fixed.png');
+
+  t.true(await pathExists(htmlOutPath));
+  t.true(await pathExists(imageOutPath));
+
+  const html = await fs.readFile(htmlOutPath, 'utf8');
+  t.regex(html, /<meta property="og:image" content="\/og-images\/fixed\.png" \/>/);
+});
+
+test.serial('integration: second Eleventy build reuses cached image (no rewrite)', async (t) => {
+  const root = await mkTmpDir(t);
+  const inputDir = path.join(root, 'input');
+  const outputDir = path.join(root, '_site');
+
+  await fs.mkdir(inputDir, { recursive: true });
+
+  await fs.writeFile(
+    path.join(inputDir, 'og-test.og.njk'),
+    `<style>.root{width:100%;height:100%;background:#000;display:flex;}</style><div class="root"></div>`,
+    'utf8',
+  );
+  await fs.writeFile(
+    path.join(inputDir, 'page.njk'),
+    `<!doctype html><html><head>{% ogImage "./og-test.og.njk" %}</head><body>ok</body></html>`,
+    'utf8',
+  );
+
+  const repoRoot = path.resolve('.');
+  const configPath = path.join(root, '.eleventy.js');
+
+  await fs.writeFile(
+    configPath,
+    `import EleventyPluginOgImage from ${JSON.stringify(path.join(repoRoot, '.eleventy.js'))};
+export default async function (eleventyConfig) {
+  eleventyConfig.addPlugin(EleventyPluginOgImage, {
+    outputFileSlug: async () => "fixed",
+    outputFileExtension: "png",
+    outputDir: "og-images",
+    urlPath: "og-images",
+    previewMode: false,
+    satoriOptions: { width: 120, height: 63, fonts: [] },
+  });
+};
+`,
+    'utf8',
+  );
+
+  const imageOutPath = path.join(outputDir, 'og-images', 'fixed.png');
+
+  const elev1 = new Eleventy(inputDir, outputDir, { configPath, quietMode: true });
+  await elev1.init();
+  await elev1.write();
+
+  const stat1 = await fs.stat(imageOutPath);
+
+  // Ensure mtime resolution changes if rewritten
+  await new Promise((r) => setTimeout(r, 20));
+
+  const elev2 = new Eleventy(inputDir, outputDir, { configPath, quietMode: true });
+  await elev2.init();
+  await elev2.write();
+
+  const stat2 = await fs.stat(imageOutPath);
+  t.is(stat2.mtimeMs, stat1.mtimeMs);
+});
+

--- a/test/eleventy-build.integration.test.js
+++ b/test/eleventy-build.integration.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-empty */
 import test from 'ava';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
@@ -5,10 +6,12 @@ import os from 'node:os';
 import Eleventy from '@11ty/eleventy';
 
 async function pathExists(p) {
-  return fs
+  const exists = await fs
     .access(p)
     .then(() => true)
     .catch(() => false);
+
+  return exists;
 }
 
 async function mkTmpDir(t) {
@@ -19,6 +22,7 @@ async function mkTmpDir(t) {
       await fs.rm(dir, { recursive: true, force: true });
     } catch {}
   });
+
   return dir;
 }
 
@@ -141,7 +145,9 @@ export default async function (eleventyConfig) {
   const stat1 = await fs.stat(imageOutPath);
 
   // Ensure mtime resolution changes if rewritten
-  await new Promise((r) => setTimeout(r, 20));
+  await new Promise((resolve) => {
+    setTimeout(resolve, 20);
+  });
 
   const elev2 = new Eleventy(inputDir, outputDir, { configPath, quietMode: true });
   await elev2.init();

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -18,6 +18,17 @@ async function createTmpDir(t) {
   return dir;
 }
 
+test('manifest save tolerates mkdir failures', async (t) => {
+  const dir = await createTmpDir(t);
+  const manifestPath = path.join(dir, 'manifest-as-file', '.og-image-manifest.json');
+  await fs.writeFile(path.join(dir, 'manifest-as-file'), 'not a dir', 'utf8');
+
+  const manifest = new OgImageManifest(manifestPath);
+  manifest.set('/page/', { dataHash: 'abc', outputFileName: 'page.png' });
+
+  await t.throwsAsync(async () => manifest.save());
+});
+
 test('manifest persists entries between load and save', async (t) => {
   const dir = await createTmpDir(t);
   const manifestPath = path.join(dir, '.og-image-manifest.json');

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -1,0 +1,58 @@
+import test from 'ava';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { OgImageManifest } from '../src/manifest.js';
+import { OgImage } from '../src/OgImage.js';
+import { buildCacheKey } from '../src/buildCache.js';
+import { mergeOptions } from '../src/utils/index.js';
+import { directoriesConfig } from './utils/directoriesConfig.js';
+
+async function createTmpDir(t) {
+  const dir = path.join(os.tmpdir(), `eleventy-plugin-og-image-manifest-${process.pid}-${Date.now()}`);
+  await fs.mkdir(dir, { recursive: true });
+  t.teardown(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  return dir;
+}
+
+test('manifest persists entries between load and save', async (t) => {
+  const dir = await createTmpDir(t);
+  const manifestPath = path.join(dir, '.og-image-manifest.json');
+  const manifest = new OgImageManifest(manifestPath);
+
+  manifest.set('/page/', { dataHash: 'abc', outputFileName: 'page.png' });
+  await manifest.save();
+
+  const reloaded = new OgImageManifest(manifestPath);
+  await reloaded.load();
+
+  t.deepEqual(reloaded.get('/page/'), { dataHash: 'abc', outputFileName: 'page.png' });
+});
+
+test('manifest entry allows resolving output filename without hashing html', async (t) => {
+  const options = mergeOptions({
+    directoriesConfig,
+    pluginOptions: {
+      slugStrategy: 'pageUrl',
+    },
+  });
+
+  const data = { page: { url: '/cached-page/' } };
+  const dataHash = buildCacheKey('./test/og-test.og.njk', data, options.optionsHash, 1000);
+
+  const ogImage = new OgImage({
+    inputPath: './test/og-test.og.njk',
+    data,
+    options,
+    templateConfig: undefined,
+    templateMtime: 1000,
+  });
+
+  ogImage.resolvedOutputFileName = 'cached-page.png';
+
+  t.is(await ogImage.outputFileName(), 'cached-page.png');
+  t.is(dataHash, buildCacheKey('./test/og-test.og.njk', data, options.optionsHash, 1000));
+});

--- a/test/pageUrlSlug.test.js
+++ b/test/pageUrlSlug.test.js
@@ -1,0 +1,28 @@
+import test from 'ava';
+import { OgImage } from '../src/OgImage.js';
+import { mergeOptions, pageUrlSlug } from '../src/utils/index.js';
+import { directoriesConfig } from './utils/directoriesConfig.js';
+
+test('pageUrlSlug converts page urls to file slugs', (t) => {
+  t.is(pageUrlSlug({ page: { url: '/blog/my-post/' } }), 'blog-my-post');
+  t.is(pageUrlSlug({ page: { url: '/' } }), 'index');
+});
+
+test('slugStrategy pageUrl resolves output path without rendering html', async (t) => {
+  const options = mergeOptions({
+    directoriesConfig,
+    pluginOptions: {
+      slugStrategy: 'pageUrl',
+    },
+  });
+
+  const ogImage = new OgImage({
+    inputPath: './test/og-test.og.njk',
+    data: { page: { url: '/example/url/' } },
+    options,
+    templateConfig: undefined,
+  });
+
+  t.is(await ogImage.outputFileSlug(), 'example-url');
+  t.is(await ogImage.outputFilePath(), './_site/og-images/example-url.png');
+});

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,0 +1,459 @@
+import test from 'ava';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import plugin from '../.eleventy.js';
+
+function createEleventyConfigStub() {
+  /** @type {Record<string, Function[]>} */
+  const listeners = Object.create(null);
+
+  /** @type {{ name: string; fn: Function } | undefined} */
+  let shortcode;
+
+  /** @type {Set<string>} */
+  const ignores = new Set();
+
+  /** @type {string[]} */
+  const logs = [];
+
+  return {
+    listeners,
+    getShortcode() {
+      if (!shortcode) {
+        throw new Error('Shortcode not registered');
+      }
+      return shortcode;
+    },
+    eleventyConfig: {
+      logger: {
+        log(msg) {
+          logs.push(String(msg));
+        },
+        get logs() {
+          return logs;
+        },
+      },
+      ignores: {
+        add(glob) {
+          ignores.add(glob);
+        },
+        get values() {
+          return ignores;
+        },
+      },
+      on(name, fn) {
+        listeners[name] ||= [];
+        listeners[name].push(fn);
+      },
+      addAsyncShortcode(name, fn) {
+        shortcode = { name, fn };
+      },
+    },
+  };
+}
+
+async function createTmpDir(t) {
+  const dir = path.join(os.tmpdir(), `eleventy-plugin-og-image-test-${process.pid}-${Date.now()}`);
+  await fs.mkdir(dir, { recursive: true });
+  t.teardown(async () => {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+    } catch {}
+  });
+  return dir;
+}
+
+test.serial('plugin registers ignores and shortcode', async (t) => {
+  const stub = createEleventyConfigStub();
+
+  await plugin(stub.eleventyConfig, {});
+
+  t.true(stub.eleventyConfig.ignores.values.size >= 1);
+  t.is(stub.getShortcode().name, 'ogImage');
+});
+
+test.serial('ogImage shortcode returns null when page.url is false', async (t) => {
+  const stub = createEleventyConfigStub();
+  await plugin(stub.eleventyConfig, {});
+
+  // Set required config for mergedOptions/joined paths (dir + config events)
+  for (const fn of stub.listeners['eleventy.directories'] || []) {
+    fn({ input: '.', output: '_site', includes: '_includes', data: '_data' });
+  }
+  for (const fn of stub.listeners['eleventy.config'] || []) {
+    fn({});
+  }
+  for (const fn of stub.listeners['eleventy.extensionmap'] || []) {
+    fn({});
+  }
+
+  const { fn: ogImageShortcode } = stub.getShortcode();
+  const result = await ogImageShortcode.call({ page: { url: false } }, './does-not-matter.og.njk');
+  t.is(result, null);
+});
+
+test.serial('ogImage shortcode throws a helpful error when input template is missing', async (t) => {
+  const stub = createEleventyConfigStub();
+  await plugin(stub.eleventyConfig, {});
+
+  for (const fn of stub.listeners['eleventy.directories'] || []) {
+    fn({ input: '.', output: '_site', includes: '_includes', data: '_data' });
+  }
+  for (const fn of stub.listeners['eleventy.config'] || []) {
+    fn({});
+  }
+  for (const fn of stub.listeners['eleventy.extensionmap'] || []) {
+    fn({});
+  }
+
+  const { fn: ogImageShortcode } = stub.getShortcode();
+
+  await t.throwsAsync(
+    async () => ogImageShortcode.call({ page: { url: '/x/' }, eleventy: {} }, './missing.og.njk'),
+    { message: /Could not find file for the `ogImage` shortcode/ },
+  );
+});
+
+test.serial('eleventy.before creates/removes preview dirs depending on runMode', async (t) => {
+  const stub = createEleventyConfigStub();
+  const root = await createTmpDir(t);
+
+  const siteDir = path.join(root, '_site');
+  const outputDir = 'out';
+  const previewDir = 'out/preview';
+
+  await plugin(stub.eleventyConfig, {
+    outputDir,
+    previewDir,
+    previewMode: 'auto',
+    // Ensure inputFileGlob is stable for ignores.add
+    inputFileGlob: '**/*.og.*',
+  });
+
+  for (const fn of stub.listeners['eleventy.directories'] || []) {
+    fn({ input: root, output: siteDir, includes: '_includes', data: '_data' });
+  }
+
+  // watch => preview enabled => mkdir previewDir
+  for (const fn of stub.listeners['eleventy.before'] || []) {
+    await fn({ runMode: 'watch' });
+  }
+  const previewStat1 = await fs.stat(path.join(siteDir, previewDir));
+  t.true(previewStat1.isDirectory());
+
+  // build => preview disabled => rm previewDir
+  for (const fn of stub.listeners['eleventy.before'] || []) {
+    await fn({ runMode: 'build' });
+  }
+  const existsAfter = await fs
+    .access(path.join(siteDir, previewDir))
+    .then(() => true)
+    .catch(() => false);
+  t.false(existsAfter);
+});
+
+test.serial('ogImage shortcode: render/write branch, cache copy branch, and preview branch', async (t) => {
+  const stub = createEleventyConfigStub();
+  const root = await createTmpDir(t);
+
+  const inputDir = path.join(root, 'input');
+  const siteDir = path.join(root, '_site');
+  const outputDir = 'og-images';
+  const previewDir = 'og-images/preview';
+  const resolvedOutputDir = path.join(siteDir, outputDir);
+  const resolvedPreviewDir = path.join(siteDir, previewDir);
+
+  await fs.mkdir(inputDir, { recursive: true });
+  await fs.mkdir(resolvedOutputDir, { recursive: true });
+
+  const inputTemplatePath = path.join(inputDir, 'og-image.og.njk');
+  await fs.writeFile(inputTemplatePath, 'stub', 'utf8');
+
+  /** @type {{ constructorArgs?: any; renderCalled: number }} */
+  const state = { constructorArgs: undefined, renderCalled: 0 };
+
+  class OgImageMock {
+    constructor(args) {
+      state.constructorArgs = args;
+    }
+    async outputFilePath() {
+      return path.join(resolvedOutputDir, 'out.png');
+    }
+    async cacheFilePath() {
+      return path.join(resolvedOutputDir, 'cache.png');
+    }
+    async render() {
+      state.renderCalled++;
+      return {
+        async toFile(fp) {
+          await fs.writeFile(fp, 'png', 'utf8');
+        },
+      };
+    }
+    previewFilePath() {
+      return path.join(resolvedPreviewDir, 'page.png');
+    }
+    async previewHtml() {
+      return '<html>preview</html>';
+    }
+    async shortcodeOutput() {
+      return 'SHORTCODE_OUTPUT';
+    }
+  }
+
+  await plugin(stub.eleventyConfig, {
+    OgImage: OgImageMock,
+    outputDir,
+    previewDir,
+    previewMode: true,
+    urlPath: 'og-images',
+    inputFileGlob: '**/*.og.*',
+  });
+
+  for (const fn of stub.listeners['eleventy.directories'] || []) {
+    fn({ input: inputDir, output: siteDir, includes: '_includes', data: '_data' });
+  }
+  for (const fn of stub.listeners['eleventy.config'] || []) {
+    fn({ template: 'config' });
+  }
+  for (const fn of stub.listeners['eleventy.extensionmap'] || []) {
+    fn({ ext: 'map' });
+  }
+
+  // Enable preview mode (sets previewEnabled + ensures dirs exist)
+  for (const fn of stub.listeners['eleventy.before'] || []) {
+    await fn({ runMode: 'build' });
+  }
+
+  const { fn: ogImageShortcode } = stub.getShortcode();
+
+  // First call: cache copy fails (cache missing) => render/write branch hit
+  const result = await ogImageShortcode.call(
+    { page: { url: '/page/' }, eleventy: { some: 'ctx' } },
+    './og-image.og.njk',
+    { extra: 1 },
+  );
+
+  t.is(result, 'SHORTCODE_OUTPUT');
+  t.is(state.renderCalled, 1);
+  t.truthy(state.constructorArgs.extensionMap);
+  t.truthy(state.constructorArgs.templateConfig);
+
+  // output file written
+  t.true(
+    await fs
+      .access(path.join(resolvedOutputDir, 'out.png'))
+      .then(() => true)
+      .catch(() => false),
+  );
+
+  // preview written
+  t.true(
+    await fs
+      .access(path.join(resolvedPreviewDir, 'page.png'))
+      .then(() => true)
+      .catch(() => false),
+  );
+  t.true(
+    await fs
+      .access(path.join(resolvedPreviewDir, 'page.png.html'))
+      .then(() => true)
+      .catch(() => false),
+  );
+
+  // log called
+  t.true(stub.eleventyConfig.logger.logs.some((l) => l.includes('Writing')));
+
+  // Second call: cache exists and copy succeeds => render not called again
+  await fs.writeFile(path.join(resolvedOutputDir, 'cache.png'), 'cached', 'utf8');
+  await fs.rm(path.join(resolvedOutputDir, 'out.png'), { force: true });
+  await ogImageShortcode.call({ page: { url: '/page/' }, eleventy: {} }, './og-image.og.njk');
+  t.is(state.renderCalled, 1);
+});
+
+test.serial('eleventy.before catches mkdir failure when outputDir is a file', async (t) => {
+  const stub = createEleventyConfigStub();
+  const root = await createTmpDir(t);
+
+  const siteDir = path.join(root, '_site');
+  const outputDir = 'output-as-file';
+  const previewDir = 'preview';
+  await fs.mkdir(siteDir, { recursive: true });
+  await fs.writeFile(path.join(siteDir, outputDir), 'not a dir', 'utf8');
+
+  await plugin(stub.eleventyConfig, {
+    outputDir,
+    previewDir,
+    previewMode: true,
+    inputFileGlob: '**/*.og.*',
+  });
+
+  for (const fn of stub.listeners['eleventy.directories'] || []) {
+    fn({ input: root, output: siteDir, includes: '_includes', data: '_data' });
+  }
+
+  // should not throw (errors are swallowed)
+  for (const fn of stub.listeners['eleventy.before'] || []) {
+    await fn({ runMode: 'build' });
+  }
+
+  t.pass();
+});
+
+test.serial('eleventy.before catches previewDir mkdir failure when previewDir is a file', async (t) => {
+  const stub = createEleventyConfigStub();
+  const root = await createTmpDir(t);
+
+  const siteDir = path.join(root, '_site');
+  await fs.mkdir(siteDir, { recursive: true });
+
+  // Make previewDir point at an existing file to force mkdir failure.
+  await fs.writeFile(path.join(siteDir, 'preview-as-file'), 'x', 'utf8');
+
+  await plugin(stub.eleventyConfig, {
+    outputDir: 'og-images',
+    previewDir: 'preview-as-file',
+    previewMode: true,
+    inputFileGlob: '**/*.og.*',
+  });
+
+  for (const fn of stub.listeners['eleventy.directories'] || []) {
+    fn({ input: root, output: siteDir, includes: '_includes', data: '_data' });
+  }
+
+  // Should not throw (mkdir failure is swallowed)
+  for (const fn of stub.listeners['eleventy.before'] || []) {
+    await fn({ runMode: 'build' });
+  }
+
+  t.pass();
+});
+
+test.serial('eleventy.before catches previewDir rm failure when previewMode is false', async (t) => {
+  const stub = createEleventyConfigStub();
+  const root = await createTmpDir(t);
+
+  const siteDir = path.join(root, '_site');
+  await fs.mkdir(siteDir, { recursive: true });
+  await fs.writeFile(path.join(siteDir, 'preview-as-file'), 'x', 'utf8');
+
+  await plugin(stub.eleventyConfig, {
+    outputDir: 'og-images',
+    // rm() against a path whose parent is a file should throw (and be swallowed)
+    previewDir: 'preview-as-file/subdir',
+    previewMode: false,
+    inputFileGlob: '**/*.og.*',
+  });
+
+  for (const fn of stub.listeners['eleventy.directories'] || []) {
+    fn({ input: root, output: siteDir, includes: '_includes', data: '_data' });
+  }
+
+  // Should not throw (rm failure is swallowed)
+  for (const fn of stub.listeners['eleventy.before'] || []) {
+    await fn({ runMode: 'build' });
+  }
+
+  t.pass();
+});
+
+test.serial('ogImage shortcode uses default OgImage when pluginOptions.OgImage is not provided', async (t) => {
+  const stub = createEleventyConfigStub();
+  const root = await createTmpDir(t);
+
+  const inputDir = path.join(root, 'input');
+  const siteDir = path.join(root, '_site');
+  await fs.mkdir(inputDir, { recursive: true });
+  await fs.mkdir(siteDir, { recursive: true });
+
+  // Real file is required for fs.access(joinedInputPath)
+  await fs.writeFile(path.join(inputDir, 'og-image.og.njk'), 'stub', 'utf8');
+
+  // Avoid heavy rendering by forcing a fixed outputFileSlug and pre-creating the output.
+  const outputDir = path.join(siteDir, 'og-images');
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(path.join(outputDir, 'fixed.png'), 'already there', 'utf8');
+
+  await plugin(stub.eleventyConfig, {
+    outputFileSlug: async () => 'fixed',
+    outputFileExtension: 'png',
+    outputDir: 'og-images',
+    previewMode: false,
+    inputFileGlob: '**/*.og.*',
+  });
+
+  for (const fn of stub.listeners['eleventy.directories'] || []) {
+    fn({ input: inputDir, output: siteDir, includes: '_includes', data: '_data' });
+  }
+  for (const fn of stub.listeners['eleventy.config'] || []) {
+    fn({}); // only passed through; not used when outputFileSlug is overridden
+  }
+  for (const fn of stub.listeners['eleventy.extensionmap'] || []) {
+    fn({});
+  }
+
+  const { fn: ogImageShortcode } = stub.getShortcode();
+  const result = await ogImageShortcode.call({ page: { url: '/x/' }, eleventy: {} }, './og-image.og.njk');
+
+  t.regex(result, /<meta property="og:image"/);
+});
+
+test.serial('ogImage shortcode catches preview mkdir error (and then throws later)', async (t) => {
+  const stub = createEleventyConfigStub();
+  const root = await createTmpDir(t);
+
+  const inputDir = path.join(root, 'input');
+  const siteDir = path.join(root, '_site');
+  const outputDir = 'og-images';
+  const previewDir = 'og-images/preview';
+  const resolvedOutputDir = path.join(siteDir, outputDir);
+  const resolvedPreviewDir = path.join(siteDir, previewDir);
+
+  await fs.mkdir(inputDir, { recursive: true });
+  await fs.mkdir(resolvedOutputDir, { recursive: true });
+  await fs.writeFile(path.join(inputDir, 'og-image.og.njk'), 'stub', 'utf8');
+  await fs.writeFile(path.join(resolvedOutputDir, 'out.png'), 'exists', 'utf8');
+
+  // Make a file where the shortcode will try to mkdir a directory
+  await fs.mkdir(resolvedPreviewDir, { recursive: true });
+  await fs.writeFile(path.join(resolvedPreviewDir, 'dir-as-file'), 'x', 'utf8');
+
+  class OgImageMock {
+    async outputFilePath() {
+      return path.join(resolvedOutputDir, 'out.png');
+    }
+    async cacheFilePath() {
+      return path.join(resolvedOutputDir, 'out.png');
+    }
+    previewFilePath() {
+      return path.join(resolvedPreviewDir, 'dir-as-file', 'page.png');
+    }
+    async previewHtml() {
+      return '<html>preview</html>';
+    }
+    async shortcodeOutput() {
+      return 'SHORTCODE_OUTPUT';
+    }
+  }
+
+  await plugin(stub.eleventyConfig, {
+    OgImage: OgImageMock,
+    outputDir,
+    previewDir,
+    previewMode: true,
+    inputFileGlob: '**/*.og.*',
+  });
+
+  for (const fn of stub.listeners['eleventy.directories'] || []) {
+    fn({ input: inputDir, output: siteDir, includes: '_includes', data: '_data' });
+  }
+  for (const fn of stub.listeners['eleventy.before'] || []) {
+    await fn({ runMode: 'build' });
+  }
+
+  const { fn: ogImageShortcode } = stub.getShortcode();
+
+  await t.throwsAsync(async () => ogImageShortcode.call({ page: { url: '/page/' }, eleventy: {} }, './og-image.og.njk'));
+});
+

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,3 +1,11 @@
+/* eslint-disable max-classes-per-file */
+/* eslint-disable no-empty */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-await-in-loop */
+/* eslint-disable class-methods-use-this */
+/* eslint-disable lines-between-class-members */
+/* eslint-disable newline-before-return */
+/* eslint-disable no-plusplus */
 import test from 'ava';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -72,6 +72,39 @@ async function createTmpDir(t) {
   return dir;
 }
 
+test.serial('eleventy.before skips manifest when manifest option is false', async (t) => {
+  const stub = createEleventyConfigStub();
+  const root = await createTmpDir(t);
+
+  const siteDir = path.join(root, '_site');
+
+  await plugin(stub.eleventyConfig, {
+    outputDir: 'og-images',
+    manifest: false,
+    inputFileGlob: '**/*.og.*',
+  });
+
+  for (const fn of stub.listeners['eleventy.directories'] || []) {
+    fn({ input: root, output: siteDir, includes: '_includes', data: '_data' });
+  }
+
+  for (const fn of stub.listeners['eleventy.before'] || []) {
+    await fn({ runMode: 'build' });
+  }
+
+  for (const fn of stub.listeners['eleventy.after'] || []) {
+    await fn();
+  }
+
+  const manifestPath = path.join(siteDir, 'og-images', '.og-image-manifest.json');
+  const exists = await fs
+    .access(manifestPath)
+    .then(() => true)
+    .catch(() => false);
+
+  t.false(exists);
+});
+
 test.serial('plugin registers ignores and shortcode', async (t) => {
   const stub = createEleventyConfigStub();
 


### PR DESCRIPTION
## Summary

This PR improves OG image build performance, especially on larger sites and incremental rebuilds, without changing the default output format or breaking existing content-addressed caching behaviour.

The plugin still uses the same Satori → Resvg → Sharp pipeline, but avoids redundant work at several stages:

- **Pre-computed options hash** — `satoriOptions` and `sharpOptions` are hashed once at plugin init, with font `data` buffers replaced by digests. This avoids re-serialising large font binaries on every shortcode invocation.
- **Build-scoped in-memory cache** — identical template input + page data within a single build reuse rendered `html`, `svg`, and `pngBuffer` results.
- **PNG passthrough** — when output is PNG and no `sharpOptions` are set, Resvg buffers are written directly via `writeToFile()`, skipping an unnecessary Sharp pass.
- **Persistent manifest** — per-page data hashes and output filenames are stored in `.og-image-manifest.json`, so rebuilds can resolve cached images without re-rendering templates when inputs are unchanged.
- **`slugStrategy: 'pageUrl'`** — optional URL-based filenames decouple output paths from content hashes, allowing path resolution without rendering OG templates first.
- **`maxConcurrency`** — optional limit on parallel Satori/Resvg rendering to reduce memory spikes on large sites.

Test coverage tooling (`c8`, integration tests, and expanded unit tests) is also included to support these changes.

## Motivation

Profiling showed that even on cache hits, the default content-hash slug strategy still renders OG templates to determine filenames. Sites with many pages or loaded fonts also paid repeated hashing/serialisation cost on every shortcode call.

These changes target that overhead while preserving backwards-compatible defaults:

| Option | Default | Behaviour |
|--------|---------|-----------|
| `slugStrategy` | `'contentHash'` | Existing content-addressed filenames |
| `manifest` | `true` | Persist lookup metadata between builds |
| `maxConcurrency` | `undefined` | Unlimited (existing behaviour) |

## New configuration options

```js
eleventyConfig.addPlugin(EleventyPluginOgImage, {
  // Optional: derive filenames from page URLs for faster incremental rebuilds
  slugStrategy: 'pageUrl',

  // Default: true — writes .og-image-manifest.json to outputDir
  manifest: true,

  // Optional: cap parallel image rendering during builds
  maxConcurrency: 4,
});
```

## Performance Improvements

Compared with the `4.3.0` baseline benchmark, this optimisation delivers a number of measurable improvements.

| Metric | Before | After | Improvement |
| ------ | ------: | -----: | ----------: |
| RSS memory increase | 1.61 GB | 1.04 GB | **35.4% reduction** |
| Heap usage increase | 427.3 MB | 332.0 MB | **22.3% reduction** |
| Average hash generation | 92.07 ms | 1.92 ms | **97.9% faster** |
| Average SVG generation | 7330.43 ms | 6805.81 ms | **7.2% faster** |
| Average PNG buffer generation | 7371.61 ms | 6842.11 ms | **7.2% faster** |
| Average shortcode execution | 41.87 ms | 1.10 ms | **97.4% faster** |

### Highlights

* 📉 **35% lower RSS (Resident Set Size) memory usage**, reducing physical RAM consumption by approximately **572 MB** during the benchmark.
* 🧠 **22% lower heap growth**, reducing JavaScript heap allocation by approximately **95 MB**.
* ⚡ **Hash generation is almost 98% faster**, dropping from ~92 ms to ~2 ms per image.
* 🖼️ **Image rendering is around 7% faster**, with improvements in both SVG generation and PNG encoding.
* 🚀 **Shortcode execution is approximately 97% faster**, reducing overhead to almost zero.

### What is RSS?

**RSS (Resident Set Size)** is the amount of **physical RAM** used by the process during execution. Unlike virtual memory, RSS represents memory that is actually resident in RAM.

A lower RSS means:

* ✅ Less memory pressure on the operating system.
* ✅ Lower risk of Out of Memory (OOM) failures in CI environments and containers.
* ✅ Better scalability when processing larger sites.
* ✅ More headroom for running multiple builds in parallel.

### Notes

* Both benchmark runs successfully generated **160/160 images** with **no failures**.
* The benchmark format changed between runs, introducing a new `writeToFile` phase. Because of that, the overall wall clock timing is **not directly comparable**, so the figures above compare equivalent phases only.

## Migration guide (4.3.x → 4.4.0)

### Overview

This release improves OG image build performance. The public API is **additive** and existing configuration continues to work. A few **default behaviours** change, so read the notes below before upgrading.

**Recommended version bump:** minor (4.4.0)

---

### No changes required for most sites

If your site:

- uses the default `contentHash` slug strategy (no custom `outputFileSlug`)
- does **not** load custom fonts via `satoriOptions.fonts`
- is fine with a new sidecar file in `outputDir`

…you can upgrade without config changes. The first build after upgrading may take slightly longer while caches repopulate; subsequent builds should be faster.

---

### 1. Manifest enabled by default

**What changed**

`manifest` now defaults to `true`. The plugin writes `.og-image-manifest.json` to `outputDir` and uses it on rebuilds to resolve cached image paths without re-rendering OG templates when inputs are unchanged.

**Who is affected**

- Sites that deploy the entire `outputDir` (the manifest file will be included)
- Sites with strict deploy allowlists of output files
- Sites where OG templates depend on global `_data`, collections, or other Eleventy context **not** passed to the `{% ogImage %}` shortcode — in rare cases a manifest hit could serve a stale image

**Migration**

To restore pre-4.4.0 behaviour:

```js
eleventyConfig.addPlugin(EleventyPluginOgImage, {
  manifest: false,
});
```

To keep the performance benefit but exclude the file from deploys, add to `.gitignore` / deploy ignore rules:

```
**/og-images/.og-image-manifest.json
```

Or delete the manifest before deploy if it is written during CI.

---

### 2. Content-addressed filenames may change for custom fonts

**What changed**

Options hashing now digests font `data` buffers instead of serialising raw binary data. This is faster and more stable, but produces **different hashes** for sites that load fonts via `satoriOptions.fonts`.

**Who is affected**

Any site using custom fonts in OG image templates.

**Impact**

- New `og:image` URLs after the first post-upgrade build
- Previously generated PNGs in `og-images/` may become orphaned
- Social platforms may continue referencing old URLs until their caches expire

**Migration**

1. Upgrade the plugin
2. Run a full production build (`npx @11ty/eleventy`)
3. Optionally remove orphaned images from `og-images/` (old hashes no longer referenced)
4. No config change required unless you want to force URL stability via `slugStrategy: 'pageUrl'` (see below)

Sites **without** custom fonts are unaffected — hashes remain the same.

---

### 3. New optional performance options

These are **opt-in** and do not require migration:

```js
eleventyConfig.addPlugin(EleventyPluginOgImage, {
  // Faster incremental rebuilds: filenames derived from page URLs
  // instead of content hashes (trade-off: no cross-page deduplication)
  slugStrategy: 'pageUrl',

  // Cap parallel Satori/Resvg work on large sites (default: unlimited)
  maxConcurrency: 4,
});
```

| Option | Default | When to use |
|--------|---------|-------------|
| `slugStrategy` | `'contentHash'` | Set `'pageUrl'` for large sites with slow incremental rebuilds |
| `manifest` | `true` | Set `false` to disable sidecar file and manifest-based path resolution |
| `maxConcurrency` | `undefined` | Set a number if builds cause high memory usage |

---

### 4. `OgImage` class extensions

If you extend `OgImage`, these additions are available but optional:

| Method / property | Purpose |
|-------------------|---------|
| `writeToFile(path)` | Writes output, using PNG passthrough when possible |
| `canPassthroughPng()` | Whether Sharp can be skipped |
| `getCacheKey()` | Build-scoped cache key for deduplication |
| `resolvedOutputFileName` | Set internally when manifest resolves a cached path |
| `templateMtime` | Template file mtime used for cache invalidation |

Existing overrides of `html()`, `svg()`, `render()`, etc. continue to work unchanged.

---

### Upgrade checklist

- [ ] Upgrade `eleventy-plugin-og-image` to 4.4.0
- [ ] Decide whether to keep `manifest: true` (default) or set `manifest: false`
- [ ] If using custom fonts, plan for regenerated OG image URLs on first build
- [ ] Run `npm run build` and verify `og:image` meta tags point to expected images
- [ ] Optionally add `.og-image-manifest.json` to deploy ignore rules
- [ ] Optionally set `maxConcurrency` if builds previously caused memory pressure

---

### Breaking changes summary

| Category | Breaking? |
|----------|-----------|
| Public API / shortcode usage | **No** |
| Default `slugStrategy` (`contentHash`) | **No** |
| Default `manifest: true` | **Behavioural change** — new output file, faster rebuilds |
| Font-loaded sites (content hashes) | **Behavioural change** — new image URLs |
| PNG output without `sharpOptions` | **No** — byte-identical output |

---

### Breaking changes (short)

None to the public API or default slug strategy.

### Behavioural changes

- `manifest` is enabled by default and writes `.og-image-manifest.json` to `outputDir`. Set `manifest: false` to opt out.
- Sites using `satoriOptions.fonts` may get new content-addressed filenames after upgrading. Run a full rebuild and update any hard-coded OG image URLs if needed.

Optimisations made using [Cursor.ai](https://cursor.com/)